### PR TITLE
Add expand-container to details conversion functionality

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -643,12 +643,13 @@ class Page(Document):
                 if macro_name in macro_handlers:
                     return macro_handlers[macro_name](el, text, parent_tags)
 
-            # Handle expand-container divs
-            if "expand-container" in str(el.get("class", "")):
-                return self.convert_expand_container(el, text, parent_tags)
-
-            if "columnLayout" in str(el.get("class", "")):
-                return self.convert_column_layout(el, text, parent_tags)
+            class_handlers = {
+                "expand-container": self.convert_expand_container,
+                "columnLayout": self.convert_column_layout,
+            }
+            for class_name, handler in class_handlers.items():
+                if class_name in str(el.get("class", "")):
+                    return handler(el, text, parent_tags)
 
             return super().convert_div(el, text, parent_tags)
 
@@ -664,14 +665,13 @@ class Page(Document):
 
             # Extract content from expand-content
             content_element = el.find("div", class_="expand-content")
-            if content_element:
-                # Recursively convert the content
-                content = self.process_tag(content_element, parent_tags)
-            else:
-                content = ""
+            # Recursively convert the content
+            content = (
+                self.process_tag(content_element, parent_tags).strip() if content_element else ""
+            )
 
             # Return as details element
-            return f"\n<details>\n<summary>{summary_text}</summary>\n\n{content}\n\n</details>\n"
+            return f"\n<details>\n<summary>{summary_text}</summary>\n{content}\n</details>\n"
 
         def convert_span(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
             if el.has_attr("data-macro-name"):


### PR DESCRIPTION
## Thank you for creating this amazing repository! 🙏

First of all, I would like to express my sincere gratitude for creating and maintaining this excellent Confluence to Markdown exporter. This tool has been incredibly helpful for our documentation workflow.

## Overview

This PR adds functionality to convert Confluence `expand-container` elements to HTML `<details>` elements, providing better support for collapsible content in the exported Markdown files.

## Changes Made

- **Added `convert_expand_container` method**: Handles the conversion of `expand-container` divs to `<details>` elements
- **Enhanced `convert_div` method**: Added detection logic for `expand-container` class with the following code:

## Implementation Details

The implementation follows the existing code patterns and integrates seamlessly with the current conversion pipeline. It extracts summary text from `expand-control-text` elements, processes content from `expand-content` elements recursively, and outputs properly formatted HTML details elements.

## Testing and Verification ✅

Functionality has been tested by exporting actual Confluence pages and verifying the correct conversion output.

## Questions and Feedback

If you have any questions about the implementation, suggestions for improvements, or would like me to make any adjustments to the code, please don't hesitate to let me know. I'm happy to address any concerns or make modifications as needed.

Thank you again for your time and consideration in reviewing this contribution! 🚀