### PR TITLE
Fix expand container formatting - Add proper line breaks after </summary> and </details> tags

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -710,7 +710,7 @@ class Page(Document):
             )
 
             # Return as details element
-            return f"\n<details>\n<summary>{summary_text}</summary>\n{content}\n</details>\n"
+            return f"\n<details>\n<summary>{summary_text}</summary>\n\n{content}\n\n</details>\n\n"
 
         def convert_span(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
             if el.has_attr("data-macro-name"):


### PR DESCRIPTION
# Fix missing line breaks in expand-container conversion
## Apology and Fix
I apologize for the oversight in my previous PR [#28](https://github.com/Spenhouet/confluence-markdown-exporter/pull/28). After the merge, I discovered an issue with the implementation and have now fixed it.

## Overview
This PR addresses an issue found in the recently merged PR #28 that added expand-container to details conversion functionality.

## Problem
After the merge, I discovered that `</summary>` and `</details>` tags lack sufficient line breaks, causing improper markdown conversion in some cases (especially with code blocks).

## Solution
Added proper line breaks after `</summary>` and `</details>` tags to ensure correct markdown formatting.

## Testing
Verified the fix works correctly with actual Confluence pages containing code blocks and other markdown elements.

