### PR TITLE
Optionally suppress breadcrumbs from generated page

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -84,6 +84,11 @@ class ConverterSettings(BaseSettings):
             "  {attachment_extension} - Attachment file extension (including leading dot)"
         ),
     )
+    page_breadcrumbs: bool = Field(
+        default=True,
+        description="Whether to include breadcrumb links at the top of the page.",
+        env="PAGE_BREADCRUMBS",
+    )
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
@@ -585,7 +590,8 @@ class Page(Document):
             md_body = self.convert(self.page.html)
             match converter_settings.markdown_style:
                 case "GFM":
-                    return f"{self.front_matter}\n{self.breadcrumbs}\n{md_body}\n"
+                    breadcrumbs = self.breadcrumbs if converter_settings.page_breadcrumbs else ""
+                    return f"{self.front_matter}\n{breadcrumbs}\n{md_body}\n"
                 case "Obsidian":
                     return f"{self.front_matter}\n{md_body}\n"
                 case _:


### PR DESCRIPTION
When migrating a single page, you might be migrating into a different page hierarchy, so the breadcrumb trail from the original hierarchy doesn't make sense. This is a new option that can leave that breadcrumb trail out of the generated markdown.

```
PAGE_BREADCRUMBS=false
```

The value defaults to true to match current behavior.