### PR TITLE
Add "pages" CLI command to export multiple pages

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/confluence_markdown_exporter/main.py",
       "justMyCode": false,
-      "args": ["page", "<page-id> or <page-url>", "scratch"],
+      "args": ["page", "<page-id> or <page-url>", "--output-path", "scratch"],
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "env": {
@@ -36,7 +36,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/confluence_markdown_exporter/main.py",
       "justMyCode": false,
-      "args": ["page-with-descendants", "<page-id> or <page-url>", "scratch"],
+      "args": ["page-with-descendants", "<page-id> or <page-url>", "--output-path", "scratch"],
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "env": {
@@ -50,7 +50,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/confluence_markdown_exporter/main.py",
       "justMyCode": false,
-      "args": ["space", "<space-key>", "scratch"],
+      "args": ["space", "<space-key>", "--output-path", "scratch"],
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "env": {
@@ -64,7 +64,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/confluence_markdown_exporter/main.py",
       "justMyCode": false,
-      "args": ["all-spaces", "scratch"],
+      "args": ["all-spaces", "--output-path", "scratch"],
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "env": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,20 @@
       }
     },
     {
+      "name": "Python: Export Multiple Pages by ID or URL",
+      "type": "debugpy",
+      "request": "launch",
+      "program": "${workspaceFolder}/confluence_markdown_exporter/main.py",
+      "justMyCode": false,
+      "args": ["pages", "<page-id-1>", "<page-id-2>", "<page-id-3>", "scratch"],
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "PYTHONPATH": "${workspaceRoot}",
+        "DEBUG": "true"
+      }
+    },
+    {
       "name": "Python: Export Page with Descendants",
       "type": "debugpy",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
       }
     },
     {
-      "name": "Python: Export Page by ID or URL",
+      "name": "Python: Export Page(s) by ID or URL",
       "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/confluence_markdown_exporter/main.py",
@@ -31,21 +31,7 @@
       }
     },
     {
-      "name": "Python: Export Multiple Pages by ID or URL",
-      "type": "debugpy",
-      "request": "launch",
-      "program": "${workspaceFolder}/confluence_markdown_exporter/main.py",
-      "justMyCode": false,
-      "args": ["pages", "<page-id-1>", "<page-id-2>", "<page-id-3>", "scratch"],
-      "console": "integratedTerminal",
-      "cwd": "${workspaceFolder}",
-      "env": {
-        "PYTHONPATH": "${workspaceRoot}",
-        "DEBUG": "true"
-      }
-    },
-    {
-      "name": "Python: Export Page with Descendants",
+      "name": "Python: Export Page(s) with Descendants",
       "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/confluence_markdown_exporter/main.py",

--- a/confluence_markdown_exporter/main.py
+++ b/confluence_markdown_exporter/main.py
@@ -20,9 +20,14 @@ def override_output_path_config(value: Path | None) -> None:
 
 
 @app.command(help="Export one or more Confluence pages by ID or URL to Markdown.")
-def page(
+def pages(
     pages: Annotated[list[str], typer.Argument(help="Page ID(s) or URL(s)")],
-    output_path: Annotated[Path | None, typer.Argument()] = None,
+    output_path: Annotated[
+        Path | None,
+        typer.Option(
+            help="Directory to write exported Markdown files to. Overrides config if set."
+        ),
+    ] = None,
 ) -> None:
     from confluence_markdown_exporter.confluence import Page
 
@@ -34,9 +39,14 @@ def page(
 
 
 @app.command(help="Export Confluence pages and their descendant pages by ID or URL to Markdown.")
-def page_with_descendants(
+def pages_with_descendants(
     pages: Annotated[list[str], typer.Argument(help="Page ID(s) or URL(s)")],
-    output_path: Annotated[Path | None, typer.Argument()] = None,
+    output_path: Annotated[
+        Path | None,
+        typer.Option(
+            help="Directory to write exported Markdown files to. Overrides config if set."
+        ),
+    ] = None,
 ) -> None:
     from confluence_markdown_exporter.confluence import Page
 
@@ -47,22 +57,33 @@ def page_with_descendants(
             _page.export_with_descendants()
 
 
-@app.command(help="Export all Confluence pages of a single space to Markdown.")
-def space(
-    space_key: Annotated[str, typer.Argument()],
-    output_path: Annotated[Path | None, typer.Argument()] = None,
+@app.command(help="Export all Confluence pages of one or more spaces to Markdown.")
+def spaces(
+    space_keys: Annotated[list[str], typer.Argument()],
+    output_path: Annotated[
+        Path | None,
+        typer.Option(
+            help="Directory to write exported Markdown files to. Overrides config if set."
+        ),
+    ] = None,
 ) -> None:
     from confluence_markdown_exporter.confluence import Space
 
-    with measure(f"Export space {space_key}"):
-        override_output_path_config(output_path)
-        space = Space.from_key(space_key)
-        space.export()
+    with measure(f"Export spaces {', '.join(space_keys)}"):
+        for space_key in space_keys:
+            override_output_path_config(output_path)
+            space = Space.from_key(space_key)
+            space.export()
 
 
 @app.command(help="Export all Confluence pages across all spaces to Markdown.")
 def all_spaces(
-    output_path: Annotated[Path | None, typer.Argument()] = None,
+    output_path: Annotated[
+        Path | None,
+        typer.Option(
+            help="Directory to write exported Markdown files to. Overrides config if set."
+        ),
+    ] = None,
 ) -> None:
     from confluence_markdown_exporter.confluence import Organization
 
@@ -74,9 +95,9 @@ def all_spaces(
 
 @app.command(help="Open the interactive configuration menu.")
 def config(
-    jump_to: str = typer.Option(
-        None, help="Jump directly to a config submenu, e.g. 'auth.confluence'"
-    ),
+    jump_to: Annotated[
+        str | None, typer.Option(help="Jump directly to a config submenu, e.g. 'auth.confluence'")
+    ] = None,
 ) -> None:
     """Interactive configuration menu."""
     main_config_menu_loop(jump_to)

--- a/confluence_markdown_exporter/main.py
+++ b/confluence_markdown_exporter/main.py
@@ -19,17 +19,31 @@ def override_output_path_config(value: Path | None) -> None:
         set_setting("export.output_path", value)
 
 
-@app.command(help="Export a single Confluence page by ID or URL to Markdown.")
-def page(
-    page: Annotated[str, typer.Argument(help="Page ID or URL")],
-    output_path: Annotated[Path | None, typer.Argument()] = None,
-) -> None:
+def _export_page(page: str, output_path: Path | None) -> None:
+    """Export a single page."""
     from confluence_markdown_exporter.confluence import Page
 
     with measure(f"Export page {page}"):
         override_output_path_config(output_path)
         _page = Page.from_id(int(page)) if page.isdigit() else Page.from_url(page)
         _page.export()
+
+
+@app.command(help="Export a single Confluence page by ID or URL to Markdown.")
+def page(
+    page: Annotated[str, typer.Argument(help="Page ID or URL")],
+    output_path: Annotated[Path | None, typer.Argument()] = None,
+) -> None:
+    _export_page(page, output_path)
+
+
+@app.command(help="Export multiple Confluence pages by ID or URL to Markdown.")
+def pages(
+    pages_list: Annotated[list[str], typer.Argument(help="Page IDs or URLs")],
+    output_path: Annotated[Path | None, typer.Argument()] = None,
+) -> None:
+    for page in pages_list:
+        _export_page(page, output_path)
 
 
 @app.command(help="Export a Confluence page and all its descendant pages by ID or URL to Markdown.")

--- a/confluence_markdown_exporter/main.py
+++ b/confluence_markdown_exporter/main.py
@@ -33,17 +33,18 @@ def page(
             _page.export()
 
 
-@app.command(help="Export a Confluence page and all its descendant pages by ID or URL to Markdown.")
+@app.command(help="Export Confluence pages and their descendant pages by ID or URL to Markdown.")
 def page_with_descendants(
-    page: Annotated[str, typer.Argument(help="Page ID or URL")],
+    pages: Annotated[list[str], typer.Argument(help="Page ID(s) or URL(s)")],
     output_path: Annotated[Path | None, typer.Argument()] = None,
 ) -> None:
     from confluence_markdown_exporter.confluence import Page
 
-    with measure(f"Export page {page} with descendants"):
-        override_output_path_config(output_path)
-        _page = Page.from_id(int(page)) if page.isdigit() else Page.from_url(page)
-        _page.export_with_descendants()
+    with measure(f"Export pages {', '.join(pages)} with descendants"):
+        for page in pages:
+            override_output_path_config(output_path)
+            _page = Page.from_id(int(page)) if page.isdigit() else Page.from_url(page)
+            _page.export_with_descendants()
 
 
 @app.command(help="Export all Confluence pages of a single space to Markdown.")

--- a/confluence_markdown_exporter/main.py
+++ b/confluence_markdown_exporter/main.py
@@ -19,31 +19,18 @@ def override_output_path_config(value: Path | None) -> None:
         set_setting("export.output_path", value)
 
 
-def _export_page(page: str, output_path: Path | None) -> None:
-    """Export a single page."""
+@app.command(help="Export one or more Confluence pages by ID or URL to Markdown.")
+def page(
+    pages: Annotated[list[str], typer.Argument(help="Page ID(s) or URL(s)")],
+    output_path: Annotated[Path | None, typer.Argument()] = None,
+) -> None:
     from confluence_markdown_exporter.confluence import Page
 
-    with measure(f"Export page {page}"):
-        override_output_path_config(output_path)
-        _page = Page.from_id(int(page)) if page.isdigit() else Page.from_url(page)
-        _page.export()
-
-
-@app.command(help="Export a single Confluence page by ID or URL to Markdown.")
-def page(
-    page: Annotated[str, typer.Argument(help="Page ID or URL")],
-    output_path: Annotated[Path | None, typer.Argument()] = None,
-) -> None:
-    _export_page(page, output_path)
-
-
-@app.command(help="Export multiple Confluence pages by ID or URL to Markdown.")
-def pages(
-    pages_list: Annotated[list[str], typer.Argument(help="Page IDs or URLs")],
-    output_path: Annotated[Path | None, typer.Argument()] = None,
-) -> None:
-    for page in pages_list:
-        _export_page(page, output_path)
+    with measure(f"Export pages {', '.join(pages)}"):
+        for page in pages:
+            override_output_path_config(output_path)
+            _page = Page.from_id(int(page)) if page.isdigit() else Page.from_url(page)
+            _page.export()
 
 
 @app.command(help="Export a Confluence page and all its descendant pages by ID or URL to Markdown.")


### PR DESCRIPTION
Addresses #43

# Before:
- Only possible to export entire spaces. It is not possible to export a small selection of pages by known ID or URL in a single command.

# After:
- Possible to export a smaller list of pages via the newly proposed "pages" argument:
`confluence-markdown-exporter pages 1 2 3`