### PR TITLE
Refactored DEBUG var to consider more intuitive boolean values

### DIFF
--- a/confluence_markdown_exporter/api_clients.py
+++ b/confluence_markdown_exporter/api_clients.py
@@ -11,8 +11,9 @@ from confluence_markdown_exporter.utils.app_data_store import ApiDetails
 from confluence_markdown_exporter.utils.app_data_store import get_settings
 from confluence_markdown_exporter.utils.app_data_store import set_setting
 from confluence_markdown_exporter.utils.config_interactive import main_config_menu_loop
+from confluence_markdown_exporter.utils.type_converter import str_to_bool
 
-DEBUG: bool = os.getenv("DEBUG", "").lower() in {"true", "1"}
+DEBUG: bool = str_to_bool(os.getenv("DEBUG", "False"))
 
 
 def response_hook(

--- a/confluence_markdown_exporter/api_clients.py
+++ b/confluence_markdown_exporter/api_clients.py
@@ -12,7 +12,7 @@ from confluence_markdown_exporter.utils.app_data_store import get_settings
 from confluence_markdown_exporter.utils.app_data_store import set_setting
 from confluence_markdown_exporter.utils.config_interactive import main_config_menu_loop
 
-DEBUG: bool = bool(os.getenv("DEBUG"))
+DEBUG: bool = os.getenv("DEBUG", "").lower() in {"true", "1"}
 
 
 def response_hook(

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -37,7 +37,7 @@ from confluence_markdown_exporter.utils.table_converter import TableConverter
 JsonResponse: TypeAlias = dict
 StrPath: TypeAlias = str | PathLike[str]
 
-DEBUG: bool = bool(os.getenv("DEBUG"))
+DEBUG: bool = os.getenv("DEBUG", "").lower() in {"true", "1"}
 
 settings = get_settings()
 confluence, jira = get_api_instances()

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -33,11 +33,12 @@ from confluence_markdown_exporter.utils.export import sanitize_filename
 from confluence_markdown_exporter.utils.export import sanitize_key
 from confluence_markdown_exporter.utils.export import save_file
 from confluence_markdown_exporter.utils.table_converter import TableConverter
+from confluence_markdown_exporter.utils.type_converter import str_to_bool
 
 JsonResponse: TypeAlias = dict
 StrPath: TypeAlias = str | PathLike[str]
 
-DEBUG: bool = os.getenv("DEBUG", "").lower() in {"true", "1"}
+DEBUG: bool = str_to_bool(os.getenv("DEBUG", "False"))
 
 settings = get_settings()
 confluence, jira = get_api_instances()

--- a/confluence_markdown_exporter/main.py
+++ b/confluence_markdown_exporter/main.py
@@ -7,8 +7,9 @@ import typer
 from confluence_markdown_exporter.utils.app_data_store import set_setting
 from confluence_markdown_exporter.utils.config_interactive import main_config_menu_loop
 from confluence_markdown_exporter.utils.measure_time import measure
+from confluence_markdown_exporter.utils.type_converter import str_to_bool
 
-DEBUG: bool = os.getenv("DEBUG", "").lower() in {"true", "1"}
+DEBUG: bool = str_to_bool(os.getenv("DEBUG", "False"))
 
 app = typer.Typer()
 

--- a/confluence_markdown_exporter/main.py
+++ b/confluence_markdown_exporter/main.py
@@ -8,7 +8,7 @@ from confluence_markdown_exporter.utils.app_data_store import set_setting
 from confluence_markdown_exporter.utils.config_interactive import main_config_menu_loop
 from confluence_markdown_exporter.utils.measure_time import measure
 
-DEBUG: bool = bool(os.getenv("DEBUG"))
+DEBUG: bool = os.getenv("DEBUG", "").lower() in {"true", "1"}
 
 app = typer.Typer()
 

--- a/confluence_markdown_exporter/utils/type_converter.py
+++ b/confluence_markdown_exporter/utils/type_converter.py
@@ -1,0 +1,12 @@
+def str_to_bool(value: str) -> bool:
+    """Convert a string to boolean."""
+    true_set = {"true", "1", "yes", "on"}
+    false_set = {"false", "0", "no", "off"}
+
+    val = value.strip().lower()
+    if val in true_set:
+        return True
+    if val in false_set:
+        return False
+    msg = f"Invalid boolean string: '{value}'"
+    raise ValueError(msg)


### PR DESCRIPTION
Addresses #47

This seems to be a common issue in Python, and I went down a little rabbit hole trying to find a good, common solution to this. See references at the bottom.

In the end, in between deprecated functions and some helper functions I've seen, I thought this approach was the simplest, but looking forward to feedback.

# Before
In [launch.json](https://github.com/Spenhouet/confluence-markdown-exporter/blob/5c1ea08754a4ce1eb5d7766dd687f4544440e180/.vscode/launch.json#L30):
```json
"env": {
  "PYTHONPATH": "${workspaceRoot}",
  "DEBUG": "false"
}
```

Results in:
`DEBUG=True`

# After
In [launch.json](https://github.com/Spenhouet/confluence-markdown-exporter/blob/5c1ea08754a4ce1eb5d7766dd687f4544440e180/.vscode/launch.json#L30):
```json
"env": {
  "PYTHONPATH": "${workspaceRoot}",
  "DEBUG": "false"
}
```

Results in:
`DEBUG=False`


---
# References
- https://danielms.site/zet/2023/pythons-distutil-strtobool-replacement/
- https://stackoverflow.com/questions/61361217/why-does-the-python-strtobool-method-return-an-int-instead-of-a-bool#:~:text=strtobool%20is%20a%20great%20function,loosely%20typed%20language%20like%20python.
- https://docs.python.org/2/distutils/apiref.html