### PR TITLE
Fix user mention username formatting for deleted users

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -18,7 +18,7 @@ from typing import cast
 
 import jmespath
 import yaml
-from atlassian.errors import ApiError
+from atlassian.errors import ApiError, ApiNotFoundError
 from bs4 import BeautifulSoup
 from bs4 import Tag
 from markdownify import ATX
@@ -827,11 +827,14 @@ class Page(Document):
 
         def convert_user_mention(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
             if el.has_attr("data-account-id"):
-                return self.convert_user(User.from_accountid(str(el.get("data-account-id"))))
+                try:
+                    return self.convert_user(User.from_accountid(str(el.get("data-account-id"))))
+                except ApiNotFoundError:
+                    print(f"User {el.get('data-account-id')} not found. Using text instead.")
 
             return self.convert_user_name(text)
 
-        def convert_user(self, user: User) -> str:
+        def convert_user(self, user: User) -> str | None:
             return self.convert_user_name(user.display_name)
 
         def convert_user_name(self, name: str) -> str:

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -18,7 +18,8 @@ from typing import cast
 
 import jmespath
 import yaml
-from atlassian.errors import ApiError, ApiNotFoundError
+from atlassian.errors import ApiError
+from atlassian.errors import ApiNotFoundError
 from bs4 import BeautifulSoup
 from bs4 import Tag
 from markdownify import ATX
@@ -826,15 +827,15 @@ class Page(Document):
             return f"{text}"
 
         def convert_user_mention(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
-            if el.has_attr("data-account-id"):
+            if aid := el.get("data-account-id"):
                 try:
-                    return self.convert_user(User.from_accountid(str(el.get("data-account-id"))))
+                    return self.convert_user(User.from_accountid(str(aid)))
                 except ApiNotFoundError:
-                    print(f"User {el.get('data-account-id')} not found. Using text instead.")
+                    print(f"User {aid} not found. Using text instead.")
 
             return self.convert_user_name(text)
 
-        def convert_user(self, user: User) -> str | None:
+        def convert_user(self, user: User) -> str:
             return self.convert_user_name(user.display_name)
 
         def convert_user_name(self, name: str) -> str:


### PR DESCRIPTION
## Issue

When user is mentioned in a page and later that user is deleted, the `data-account-id` exists but that user doesn't exist in the Confluence instance anymore.

With current implementation `User.from_accountid` will raise an exception and the exporter will fail:

```
│ /Users/Taadas/indexer/.venv/lib/python3.11/site-packages/confluence_markdown_exporter/confluence.py:838 in convert_user_mention                                                              
│                                                                                                                                                                                              
│   835 │   │                                                                                                                                                                                  
│   836 │   │   def convert_user_mention(self, el: BeautifulSoup, text: str, parent_tags: list[s                                                                                               
│   837 │   │   │   if el.has_attr("data-account-id"):                                                                                                                                         
│ ❱ 838 │   │   │   │   return self.convert_user(User.from_accountid(str(el.get("data-account-id                                                                                               
│   839 │   │   │   │   # try:                                                                                                                                                                 
│   840 │   │   │   │   #     return self.convert_user(User.from_accountid(str(el.get("data-acco                                                                                               
│   841 │   │   │   │   # except ApiNotFoundError as ex:                                                                                                                                       
│                                                                                                                                                                                              
│ ╭───────────────────────────────────────────────────────────────────────────────────────── locals ──────────────────────────────────────────────────────────────────────────────────────────╮
│ │          el = <a class="confluence-userlink user-mention" data-account-id="xxxxxxxxxxxxxxxxxxxxxxxx" data-base-url="https://example.atlassian.net/wiki">Dolan Duck (Unlicensed)</a>       │
│ │ parent_tags = {'td', 'div', 'tr', '_inline', 'p', 'table', '[document]', 'tbody'}                                                                                                         │
│ │        self = <confluence_markdown_exporter.confluence.Page.Converter object at 0x107bbf190>                                                                                              │
│ │        text = 'Dolan Duck (Unlicensed)'                                                                                                                                                   │
│ ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
│                                                                                                                                                                                              
│ /Users/Taadas/indexer/.venv/lib/python3.11/site-packages/confluence_markdown_exporter/confluence.py:140 in from_accountid                                                                    
│                                                                                                                                                                                              
│   137 │   @functools.lru_cache(maxsize=100)                                                    ╭──────────────── locals ────────────────╮                                                    
│   138 │   def from_accountid(cls, accountid: str) -> "User":                                   │ accountid = 'xxxxxxxxxxxxxxxxxxxxxxxx' │                                                    
│   139 │   │   return cls.from_json(                                                            ╰────────────────────────────────────────╯                                                    
│ ❱ 140 │   │   │   cast(JsonResponse, confluence.get_user_details_by_accountid(accountid))                                                                                                    
│   141 │   │   )                                                                                                                                                                              
│   142                                                                                                                                                                                        
│   143                                                                                                                                                                                        
│                                                                                                                                                                                              
│ /Users/Taadas/indexer/.venv/lib/python3.11/site-packages/atlassian/confluence.py:2709 in get_user_details_by_accountid                                                                       
│                                                                                                                                                                                              
│   2706 │   │   │   │   │   reason=e,                                                            ╭────────────────────────────── locals ───────────────────────────────╮                      
│   2707 │   │   │   │   )                                                                        │ accountid = 'xxxxxxxxxxxxxxxxxxxxxxxx'                              │                      
│   2708 │   │   │   if e.response.status_code == 404:                                            │    expand = None                                                    │                      
│ ❱ 2709 │   │   │   │   raise ApiNotFoundError(                                                  │    params = {'accountId': 'xxxxxxxxxxxxxxxxxxxxxxxx'}               │                      
│   2710 │   │   │   │   │   "The user with the given account does not exist",                    │      self = <atlassian.confluence.Confluence object at 0x107502cd0> │                      
│   2711 │   │   │   │   │   reason=e,                                                            │       url = 'rest/api/user'                                         │                      
│   2712 │   │   │   │   )                                                                        ╰─────────────────────────────────────────────────────────────────────╯                      
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
ApiNotFoundError: The user with the given account does not exist
```

## Solution

If user is not found, fallback to the extracting username from the string. I thought about doing this for all users, but decided to only do this for deleted users, because I don't know all the use cases of the username field.