### PR TITLE
Fix descendants pagination fetching

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -16,7 +16,6 @@ from typing import Literal
 from typing import TypeAlias
 from typing import cast
 
-import jmespath
 import yaml
 from atlassian.errors import ApiError
 from bs4 import BeautifulSoup
@@ -322,31 +321,23 @@ class Page(Document):
 
     @property
     def descendants(self) -> list[int]:
-        cql_query = f"ancestor={self.id} AND type=page"
-        page_ids = []
-        start = 0
-        paging_limit = 100
-        total_size = paging_limit  # Initialize to limit to enter the loop
-
-        ids_exp = jmespath.compile("results[].content.id.to_number(@)")
+        url = "rest/api/content/search"
+        params = {
+            'cql': f'type=page AND ancestor={self.id}',
+            'limit': 100
+        }
+        results = []
 
         try:
-            while start < total_size:
-                response = cast(
-                    JsonResponse,
-                    confluence.cql(cql_query, limit=paging_limit, start=start),
-                )
+            response = confluence.get(url, params=params)
+            results.extend(response.get('results', []))
+            next = response.get('_links').get('next')
 
-                page_ids.extend(ids_exp.search(response))
-
-                size = response.get("size", 0)
-                total_size = response.get("totalSize", 0)
-
-                if size == 0:
-                    break
-
-                start += size
-
+            while next:
+                response = confluence.get(next)
+                results.extend(response.get('results', []))
+                next = response.get('_links').get('next')
+                    
         except HTTPError as e:
             if e.response.status_code == 404:  # noqa: PLR2004
                 print(
@@ -360,6 +351,7 @@ class Page(Document):
             )
             return []
 
+        page_ids = [result['id'] for result in results]
         return page_ids
 
     @property


### PR DESCRIPTION
## Issue

When fetching pages from Confluence, only the first batch of pages is fetched, and next batches returns duplicate pages.
This happens because there is a bug in the Atlassian Python API -
https://github.com/atlassian-api/atlassian-python-api/issues/820. `start` is deprecated from July 15th, 2020
(https://developer.atlassian.com/cloud/confluence/change-notice-moderize-search-rest-apis/) and the `cursor` paramater
(or a `next` link) should be used instead.

## Solution

Use `next` link to fetch pages in `descendants` method.