### PR TITLE
Fix unhandled exception that stops export process when user acount does not have permission for a single page

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/confluence_markdown_exporter/main.py",
       "justMyCode": false,
-      "args": ["page", "<page-id> or <page-url>", "--output-path", "scratch"],
+      "args": ["pages", "<page-id> or <page-url>", "--output-path", "scratch"],
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "env": {
@@ -36,7 +36,7 @@
       "request": "launch",
       "program": "${workspaceFolder}/confluence_markdown_exporter/main.py",
       "justMyCode": false,
-      "args": ["page-with-descendants", "<page-id> or <page-url>", "--output-path", "scratch"],
+      "args": ["pages-with-descendants", "<page-id> or <page-url>", "--output-path", "scratch"],
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "env": {
@@ -45,12 +45,12 @@
       }
     },
     {
-      "name": "Python: Export Space",
+      "name": "Python: Export Space(s)",
       "type": "debugpy",
       "request": "launch",
       "program": "${workspaceFolder}/confluence_markdown_exporter/main.py",
       "justMyCode": false,
-      "args": ["space", "<space-key>", "--output-path", "scratch"],
+      "args": ["spaces", "<space-key>", "--output-path", "scratch"],
       "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "env": {

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -387,6 +387,10 @@ class Page(Document):
         return self.Converter(self).markdown
 
     def export(self) -> None:
+        if self.title == "[Error: Page not accessible]":
+            print(f"Skipping export for inaccessible page with ID {self.id}")
+            return
+
         if DEBUG:
             self.export_body()
         self.export_markdown()
@@ -481,7 +485,7 @@ class Page(Document):
                     ),
                 )
             )
-        except ApiError as e:
+        except (ApiError, HTTPError) as e:
             print(f"WARNING: Could not access page with ID {page_id}: {e!s}")
             # Return a minimal page object with error information
             return cls(

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -387,10 +387,6 @@ class Page(Document):
         return self.Converter(self).markdown
 
     def export(self) -> None:
-        if self.title == "[Error: Page not accessible]":
-            print(f"Skipping export for inaccessible page with ID {self.id}")
-            return
-
         if DEBUG:
             self.export_body()
         self.export_markdown()

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -390,6 +390,10 @@ class Page(Document):
         return self.Converter(self).markdown
 
     def export(self) -> None:
+        if self.title == "Page not accessible":
+            print(f"Skipping export for inaccessible page with ID {self.id}")
+            return
+
         if DEBUG:
             self.export_body()
         self.export_markdown()
@@ -497,12 +501,12 @@ class Page(Document):
                     ),
                 )
             )
-        except (ApiError, HTTPError) as e:
+        except ApiError as e:
             print(f"WARNING: Could not access page with ID {page_id}: {e!s}")
             # Return a minimal page object with error information
             return cls(
                 id=page_id,
-                title="[Error: Page not accessible]",
+                title="Page not accessible",
                 space=Space(key="", name="", description="", homepage=0),
                 body="",
                 body_export="",

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -188,7 +188,7 @@ class ExportConfig(BaseModel):
         description="Whether to include breadcrumb links at the top of the page.",
     )
     filename_encoding: str = Field(
-        default='"<":"_",">":"_",":":"_","\\"":"_","/":"_","\\\\":"_","|":"_","?":"_","*":"_","\\u0000":"_"',
+        default='"<":"_",">":"_",":":"_","\\"":"_","/":"_","\\\\":"_","|":"_","?":"_","*":"_","\\u0000":"_","[":"_","]":"_"',
         title="Filename Encoding",
         description=(
             "List character-to-replacement pairs, separated by commas. "


### PR DESCRIPTION
Addresses #51

# Before:
See #51

# After:
When running `confluence-markdown-exporter pages 1 2 3` and assuming no permissions for page 2 - pages 1 and 3 will be exported and the following logs (redacted) are visible:

```
Export pages 1, 2, 3 started at 2025-07-08 __:__:__
WARNING: Could not access page with ID ___: com.atlassian.confluence.api.service.exceptions.PermissionException: User ___:___ does not have view permissions on entity page: 2 v.170
Skipping export for inaccessible page with ID 2
Export pages 1, 2, 3 ended at 2025-07-08 __:__:__
Export pages 1, 2, 3 took relativedelta(seconds=+__, microseconds=+___)
```
---
Additionally, launch.json was failing due to the recent change of commands to plural, I've fixed that as an add-on commit to this PR. It's not really within the strict scope of the issue, but I did not want to spam too many PRs. Please let me know if you prefer to split that commit instead or feel free to commit it directly yourself.