### PR TITLE
Add verify_ssl setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,12 @@ This will open a menu where you can:
 | export.filename_encoding | Character mapping for filename encoding. | Default mappings for forbidden characters. |
 | export.filename_length | Maximum length of filenames. | 255 |
 | export.include_document_title | Whether to include the document title in the exported markdown file. | True |
-| retry_config.backoff_and_retry | Enable automatic retry with exponential backoff | True |
-| retry_config.backoff_factor | Multiplier for exponential backoff | 2 |
-| retry_config.max_backoff_seconds | Maximum seconds to wait between retries | 60 |
-| retry_config.max_backoff_retries | Maximum number of retry attempts | 5 |
-| retry_config.retry_status_codes | HTTP status codes that trigger a retry | \[413, 429, 502, 503, 504\] |
+| connection_config.backoff_and_retry | Enable automatic retry with exponential backoff | True |
+| connection_config.backoff_factor | Multiplier for exponential backoff | 2 |
+| connection_config.max_backoff_seconds | Maximum seconds to wait between retries | 60 |
+| connection_config.max_backoff_retries | Maximum number of retry attempts | 5 |
+| connection_config.retry_status_codes | HTTP status codes that trigger a retry | \[413, 429, 502, 503, 504\] |
+| connection_config.verify_ssl | Whether to verify SSL certificates for HTTPS requests. | True |
 | auth.confluence.url | Confluence instance URL | "" |
 | auth.confluence.username | Confluence username/email | "" |
 | auth.confluence.api_token | Confluence API token | "" |

--- a/confluence_markdown_exporter/api_clients.py
+++ b/confluence_markdown_exporter/api_clients.py
@@ -30,8 +30,8 @@ def response_hook(
 class ApiClientFactory:
     """Factory for creating authenticated Confluence and Jira API clients with retry config."""
 
-    def __init__(self, retry_config: dict[str, Any]) -> None:
-        self.retry_config = retry_config
+    def __init__(self, connection_config: dict[str, Any]) -> None:
+        self.connection_config = connection_config
 
     def create_confluence(self, auth: ApiDetails) -> ConfluenceApiSdk:
         try:
@@ -40,7 +40,7 @@ class ApiClientFactory:
                 username=auth.username,
                 password=auth.api_token.get_secret_value() if auth.api_token else None,
                 token=auth.pat.get_secret_value() if auth.pat else None,
-                **self.retry_config,
+                **self.connection_config,
             )
             instance.get_all_spaces(limit=1)
         except Exception as e:
@@ -55,7 +55,7 @@ class ApiClientFactory:
                 username=auth.username,
                 password=auth.api_token.get_secret_value() if auth.api_token else None,
                 token=auth.pat.get_secret_value() if auth.pat else None,
-                **self.retry_config,
+                **self.connection_config,
             )
             instance.get_all_projects()
         except Exception as e:
@@ -68,11 +68,11 @@ def get_confluence_instance() -> ConfluenceApiSdk:
     """Get authenticated Confluence API client using current settings."""
     settings = get_settings()
     auth = settings.auth
-    retry_config = settings.retry_config.model_dump()
+    connection_config = settings.connection_config.model_dump()
 
     while True:
         try:
-            confluence = ApiClientFactory(retry_config).create_confluence(auth.confluence)
+            confluence = ApiClientFactory(connection_config).create_confluence(auth.confluence)
             break
         except ConnectionError:
             questionary.print(
@@ -94,11 +94,11 @@ def get_jira_instance() -> JiraApiSdk:
     """Get authenticated Jira API client using current settings with required authentication."""
     settings = get_settings()
     auth = settings.auth
-    retry_config = settings.retry_config.model_dump()
+    connection_config = settings.connection_config.model_dump()
 
     while True:
         try:
-            jira = ApiClientFactory(retry_config).create_jira(auth.jira)
+            jira = ApiClientFactory(connection_config).create_jira(auth.jira)
             break
         except ConnectionError:
             # Ask if user wants to use Confluence credentials for Jira

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -29,8 +29,8 @@ def get_app_config_path() -> Path:
 APP_CONFIG_PATH = get_app_config_path()
 
 
-class RetryConfig(BaseModel):
-    """Configuration for network retry behavior."""
+class ConnectionConfig(BaseModel):
+    """Configuration for the connection like retry options."""
 
     backoff_and_retry: bool = Field(
         default=True,
@@ -227,7 +227,9 @@ class ConfigModel(BaseModel):
     """Top-level application configuration model."""
 
     export: ExportConfig = Field(default_factory=ExportConfig, title="Export Settings")
-    retry_config: RetryConfig = Field(default_factory=RetryConfig, title="Retry/Network Settings")
+    connection_config: ConnectionConfig = Field(
+        default_factory=ConnectionConfig, title="Connection Configuration"
+    )
     auth: AuthConfig = Field(default_factory=AuthConfig, title="Authentication")
 
 
@@ -269,7 +271,7 @@ def get_settings() -> ConfigModel:
     data = load_app_data()
     return ConfigModel(
         export=ExportConfig(**data.get("export", {})),
-        retry_config=RetryConfig(**data.get("retry_config", {})),
+        connection_config=ConnectionConfig(**data.get("connection_config", {})),
         auth=AuthConfig(**data.get("auth", {})),
     )
 

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -60,6 +60,14 @@ class RetryConfig(BaseModel):
         title="Retry Status Codes",
         description="HTTP status codes that should trigger a retry.",
     )
+    verify_ssl: bool = Field(
+        default=True,
+        title="Verify SSL",
+        description=(
+            "Whether to verify SSL certificates for HTTPS requests. "
+            "Set to False only if you are sure about the security of your connection."
+        ),
+    )
 
 
 class ApiDetails(BaseModel):


### PR DESCRIPTION
Given that the ApiClientFactory takes the retry_config from settings.retry_config.model_dump(), adding this verify_ssl bool field allows us to skip ssl checking, which is passed to the Confluence API, and it in turn gets passed to the requests library.

Then just modifying the json with the settings is enough to set this as False, so I can skip this step.

This is necessary to be able of using this project in my corporate intranet.

Let me know if this is OK with you.

I do feel like it being added on RetryConfig isn't ideal, maybe renaming RetryConfig to ConnectionConfig might be better. If that sounds better to you, let me know and I can do the necessary changes to it.