### PR TITLE
Remove pandas as a dependency

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -46,7 +46,6 @@ select = [
   "W", # pycodestyle warnings
   "C4", # flake8-comprehensions
   "EM", # flake8-errmsg
-  "PD", # pandas-vet
   "PL", # Pylint
   "UP", # pyupgrade - auto-upgrade syntax for current version of Python
   "ANN", # flake8-annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     'atlassian-python-api',
     'jmespath',
     'markdownify',
-    'pandas',
     'pydantic-settings',
     'pyyaml',
     'questionary',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 atlassian-python-api
 jmespath
 markdownify
-pandas
 pydantic-settings
 pyyaml
 questionary


### PR DESCRIPTION
As discussed in #62 pandas is not inherited from other dependencies, nor does it seem to be needed in the current implementation.