### PR TITLE
added config file location text to config menu

### DIFF
--- a/confluence_markdown_exporter/utils/config_interactive.py
+++ b/confluence_markdown_exporter/utils/config_interactive.py
@@ -15,6 +15,7 @@ from confluence_markdown_exporter.utils.app_data_store import ConfigModel
 from confluence_markdown_exporter.utils.app_data_store import get_settings
 from confluence_markdown_exporter.utils.app_data_store import reset_to_defaults
 from confluence_markdown_exporter.utils.app_data_store import set_setting
+from confluence_markdown_exporter.utils.app_data_store import get_app_config_path
 
 custom_style = Style(
     [
@@ -237,6 +238,7 @@ def _main_config_menu(settings: dict, default: tuple[str, bool] | None = None) -
                 default_value = c.value
                 break
     return questionary.select(
+        f"Config file location: {get_app_config_path()}\n\n" \
         "Select a config to change (or reset):",
         choices=choices,
         style=custom_style,


### PR DESCRIPTION
Addresses #67 

# Before:
<img width="524" height="134" alt="image" src="https://github.com/user-attachments/assets/2fa2cfb6-3eb2-4b24-961b-996e30e071cc" />

# After:
<img width="895" height="178" alt="image" src="https://github.com/user-attachments/assets/22cd7781-d6c4-4871-b9ce-04c6fcbe07b8" />

Notice that many modern terminals allow you to CTRL+LMB, which instantly opens the file in that path.

I opted for the simplest and easiest to maintain option, but let me know if you'd like to swap it or if you have any comments/additions.


---

# Implementation choices
I came up with two potential ways of implementing this:

## A) Simple text
This is the one I picked, mostly due to its simplicity and because of the modern terminal functionality mentioned above. It achieves identical functionality to B), while sidestepping many of its issues

## B) Opens the file directly
Could be achieved by adding an additional button in the config options (at [_get_choices()](https://github.com/Spenhouet/confluence-markdown-exporter/blob/67a63a08d0019c363267c42026715787d1ffe628/confluence_markdown_exporter/utils/config_interactive.py#L297) and [_edit_dict_config_loop()](https://github.com/Spenhouet/confluence-markdown-exporter/blob/67a63a08d0019c363267c42026715787d1ffe628/confluence_markdown_exporter/utils/config_interactive.py#L327))

This button then would require OS-specific code to inject the config path into some sort of shell, process or subprocess, like so, in [app_data_store.py](https://github.com/Spenhouet/confluence-markdown-exporter/blob/67a63a08d0019c363267c42026715787d1ffe628/confluence_markdown_exporter/utils/app_data_store.py):

```python
def open_config_folder() -> None:
    """Open the folder containing the app config file."""
    config_path: Path = get_app_config_path()
    if not config_path.exists():
        print(f"Config file does not exist: {config_path}")
        return
    try:
        if os.name == 'windows':
            import shutil
            explorer_path = shutil.which('explorer')
            if explorer_path and Path(explorer_path).is_file():
                # Validate that explorer_path is a real file
                subprocess.run([explorer_path, str(config_path.parent)], check=True)
            else:
                raise FileNotFoundError("explorer.exe not found in PATH")
        elif os.name == 'macos':
            (and so on for other OS'es...)
    except Exception as e:
        print(f"Failed to open config folder: {e}")
```



Either way, this would add the extra responsibility of being very careful in validating what gets sent and executed to the user's shell. Since that input comes from the config file, it is possible someone could write code there and have it executed in the shell, thus catching that input and validating/sanitizing it could add significant complexity.

