### PR TITLE
Added fallback differentiation to avoid recursion depth issues

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -807,23 +807,35 @@ class Page(Document):
         def convert_a(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:  # noqa: PLR0911
             if "user-mention" in str(el.get("class")):
                 return self.convert_user_mention(el, text, parent_tags)
+
             if "createpage.action" in str(el.get("href")) or "createlink" in str(el.get("class")):
                 if fallback := BeautifulSoup(self.page.editor2, "html.parser").find(
                     "a", string=text
                 ):
-                    return self.convert_a(fallback, text, parent_tags)  # type: ignore -
+
+                    fallback_href = fallback.get("href", "")
+                    fallback_class = fallback.get("class", [])
+
+                    if( "createpage.action" not in str(fallback_href) and
+                        "createlink" not in str(fallback_class)):
+                        return self.convert_a(fallback, text, parent_tags)  # type: ignore -
+
                 return f"[[{text}]]"
+
             if "page" in str(el.get("data-linked-resource-type")):
                 page_id = str(el.get("data-linked-resource-id", ""))
                 if page_id and page_id != "null":
                     return self.convert_page_link(int(page_id))
+
             if "attachment" in str(el.get("data-linked-resource-type")):
                 link = self.convert_attachment_link(el, text, parent_tags)
                 # convert_attachment_link may return None if the attachment meta is incomplete
                 return link or f"[{text}]({el.get('href')})"
+
             if match := re.search(r"/wiki/.+?/pages/(\d+)", str(el.get("href", ""))):
                 page_id = match.group(1)
                 return self.convert_page_link(int(page_id))
+
             if str(el.get("href", "")).startswith("#"):
                 # Handle heading links
                 return f"[{text}](#{sanitize_key(text, '-')})"

--- a/confluence_markdown_exporter/main.py
+++ b/confluence_markdown_exporter/main.py
@@ -33,8 +33,8 @@ def pages(
     from confluence_markdown_exporter.confluence import Page
 
     with measure(f"Export pages {', '.join(pages)}"):
+        override_output_path_config(output_path)
         for page in pages:
-            override_output_path_config(output_path)
             _page = Page.from_id(int(page)) if page.isdigit() else Page.from_url(page)
             _page.export()
 
@@ -52,8 +52,8 @@ def pages_with_descendants(
     from confluence_markdown_exporter.confluence import Page
 
     with measure(f"Export pages {', '.join(pages)} with descendants"):
+        override_output_path_config(output_path)
         for page in pages:
-            override_output_path_config(output_path)
             _page = Page.from_id(int(page)) if page.isdigit() else Page.from_url(page)
             _page.export_with_descendants()
 
@@ -71,8 +71,8 @@ def spaces(
     from confluence_markdown_exporter.confluence import Space
 
     with measure(f"Export spaces {', '.join(space_keys)}"):
+        override_output_path_config(output_path)
         for space_key in space_keys:
-            override_output_path_config(output_path)
             space = Space.from_key(space_key)
             space.export()
 


### PR DESCRIPTION
Addresses #73

# Before
<img width="1218" height="100" alt="image" src="https://github.com/user-attachments/assets/0afc379a-7a37-4eed-a84a-193d398c0d4e" />

see issue above for more details

# After
No recursion error for old Confluence pages anymore