### PR TITLE
added setting to export all files regardless of reference in page

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -432,22 +432,26 @@ class Page(Document):
         )
 
     def export_attachments(self) -> None:
-        for attachment in self.attachments:
-            if (
-                attachment.filename.endswith(".drawio")
-                and f"diagramName={attachment.title}" in self.body
-            ):
+        if settings.export.attachment_export_all:
+            for attachment in self.attachments:
                 attachment.export()
-                continue
-            if (
-                attachment.filename.endswith(".drawio.png")
-                and attachment.title.replace(" ", "%20") in self.body_export
-            ):
-                attachment.export()
-                continue
-            if attachment.file_id in self.body:
-                attachment.export()
-                continue
+        else:
+            for attachment in self.attachments:
+                if (
+                    attachment.filename.endswith(".drawio")
+                    and f"diagramName={attachment.title}" in self.body
+                ):
+                    attachment.export()
+                    continue
+                if (
+                    attachment.filename.endswith(".drawio.png")
+                    and attachment.title.replace(" ", "%20") in self.body_export
+                ):
+                    attachment.export()
+                    continue
+                if attachment.file_id in self.body:
+                    attachment.export()
+                    continue
 
     def get_attachment_by_id(self, attachment_id: str) -> Attachment | None:
         """Get the Attachment object by its ID.

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -190,6 +190,15 @@ class ExportConfig(BaseModel):
         ),
         examples=["{space_name}/attachments/{attachment_file_id}{attachment_extension}"],
     )
+    attachment_export_all: bool = Field(
+        default=False,
+        title="Attachment Export All",
+        description=(
+            "Whether to export all attachments or only the ones whose ID "
+            "is referred in the page."
+            "\nNote: large and multiple attachments will take more time"
+        ),
+    )
     page_breadcrumbs: bool = Field(
         default=True,
         title="Page Breadcrumbs",


### PR DESCRIPTION
Addresses #79 

# Before:
See issue above
<img width="554" height="325" alt="image" src="https://github.com/user-attachments/assets/de6213af-a539-4302-8928-813f425b26ac" />

# After:
<img width="508" height="392" alt="image" src="https://github.com/user-attachments/assets/eb1f6475-57ea-442b-a39f-b6c6f9ad9455" />
<img width="708" height="374" alt="image" src="https://github.com/user-attachments/assets/5fb4e620-3eb3-482b-8cc0-69015841a4cf" />
<img width="955" height="178" alt="image" src="https://github.com/user-attachments/assets/875e6bcd-1022-4ec7-91b8-2b6d764f2b76" />



The Confluence space in the issue is the same as in this PR.
