### PR TITLE
Update command syntax to use --output-path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ Run the exporter with the desired Confluence page ID or space key. Execute the c
 Export a single Confluence page by ID:
 
 ```sh
-confluence-markdown-exporter pages <page-id e.g. 645208921> <output path e.g. ./output_path/>
+confluence-markdown-exporter pages <page-id e.g. 645208921> --output-path <output path e.g. ./output_path/>
 ```
 
 or by URL:
 
 ```sh
-confluence-markdown-exporter pages <page-url e.g. https://company.atlassian.net/MySpace/My+Page+Title> <output path e.g. ./output_path/>
+confluence-markdown-exporter pages <page-url e.g. https://company.atlassian.net/MySpace/My+Page+Title> --output-path <output path e.g. ./output_path/>
 ```
 
 #### 2.2. Export Page with Descendants
@@ -74,13 +74,13 @@ confluence-markdown-exporter pages <page-url e.g. https://company.atlassian.net/
 Export a Confluence page and all its descendant pages by page ID:
 
 ```sh
-confluence-markdown-exporter pages-with-descendants <page-id e.g. 645208921> <output path e.g. ./output_path/>
+confluence-markdown-exporter pages-with-descendants <page-id e.g. 645208921> --output-path <output path e.g. ./output_path/>
 ```
 
 or by URL:
 
 ```sh
-confluence-markdown-exporter pages-with-descendants <page-url e.g. https://company.atlassian.net/MySpace/My+Page+Title> <output path e.g. ./output_path/>
+confluence-markdown-exporter pages-with-descendants <page-url e.g. https://company.atlassian.net/MySpace/My+Page+Title> --output-path <output path e.g. ./output_path/>
 ```
 
 #### 2.3. Export Space
@@ -88,7 +88,7 @@ confluence-markdown-exporter pages-with-descendants <page-url e.g. https://compa
 Export all Confluence pages of a single Space:
 
 ```sh
-confluence-markdown-exporter spaces <space-key e.g. MYSPACE> <output path e.g. ./output_path/>
+confluence-markdown-exporter spaces <space-key e.g. MYSPACE> --output-path <output path e.g. ./output_path/>
 ```
 
 #### 2.3. Export all Spaces
@@ -96,7 +96,7 @@ confluence-markdown-exporter spaces <space-key e.g. MYSPACE> <output path e.g. .
 Export all Confluence pages across all spaces:
 
 ```sh
-confluence-markdown-exporter all-spaces <output path e.g. ./output_path/>
+confluence-markdown-exporter all-spaces --output-path <output path e.g. ./output_path/>
 ```
 
 ### 3. Output


### PR DESCRIPTION
<!--
Thank you for contributing to confluence-markdown-exporter! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

<!-- What's the purpose of the change? What does it do, and why? -->
The purpose is to provide clearer documentation that aligns with the current command syntax.

## Test Plan

<!-- How was it tested? -->
When running the command as written in the README, I received URL parse errors. When I ran `cf-export pages --help`, it showed that the option `--output-path` can be used. Once I included this before my path, the command completed successfully.
