### PR TITLE
Use the same logic in convert_img as in convert_attachment_link to fix images

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -901,6 +901,10 @@ class Page(Document):
             attachment = None
             if fid := el.get("data-media-id"):
                 attachment = self.page.get_attachment_by_file_id(str(fid))
+            if not attachment and (fid := el.get("data-media-id")):
+                attachment = self.page.get_attachment_by_file_id(str(fid))
+            if not attachment and (aid := el.get("data-linked-resource-id")):
+                attachment = self.page.get_attachment_by_id(str(aid))
 
             if attachment is None:
                 href = el.get("href") or text


### PR DESCRIPTION
This fixes #98

## Summary

The purpose of this change is to fix an issue I had and others had on #98 . It copies the same logic from convert_attachment_link and puts it into convert_img so it works

## Test Plan

I ran this against my company's confluence which is an onprem confluence instance.
