### PR TITLE
fix(confluence): handle spaces w/o a homepage

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -219,15 +219,17 @@ class Document(BaseModel):
 
     @property
     def _template_vars(self) -> dict[str, str]:
+        homepage_id = ""
         homepage_title = ""
         if self.space.homepage:
+            homepage_id = str(self.space.homepage)
             homepage_title = sanitize_filename(Page.from_id(self.space.homepage).title)
 
         return {
             "space_key": sanitize_filename(self.space.key),
             "space_name": sanitize_filename(self.space.name),
-            "homepage_id": str(self.space.homepage),
-            "homepage_title": sanitize_filename(Page.from_id(self.space.homepage).title),
+            "homepage_id": homepage_id,
+            "homepage_title": homepage_title,
             "ancestor_ids": "/".join(str(a.id) for a in self.ancestors),
             "ancestor_titles": "/".join(sanitize_filename(a.title) for a in self.ancestors),
         }


### PR DESCRIPTION


<!--
Thank you for contributing to confluence-markdown-exporter! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change? (See below.)
- Does this pull request include a descriptive title?
- Does this pull request include references to any relevant issues?
-->

## Summary

Support spaces without homepage.

Closes #14

## Test Plan

I had the issue described in #14 , after the changes I am able to pull down the confluence pages.
