### PR TITLE
Honor the SSL verification setting during attachments download

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -321,8 +321,8 @@ class Attachment(Document):
             return
 
         try:
-            verify_ssl = getattr(settings.connection_config, "verify_ssl", True)
-            response = confluence._session.get(str(confluence.url + self.download_link), verify=verify_ssl)
+            verify_ssl = settings.connection_config.verify_ssl
+            response = confluence._session.get(str(confluence.url + self.download_link), verify_ssl)
             response.raise_for_status()  # Raise error if request fails
         except HTTPError:
             logger.warning(f"There is no attachment with title '{self.title}'. Skipping export.")


### PR DESCRIPTION
Honor the SSL verification setting during attachments download

## Summary
When connection_config.verify_ssl is True that is not passed to the code for downloading attachments 