### PR TITLE
fix: handle non-list parent_tags in table converter

### DIFF
--- a/confluence_markdown_exporter/utils/table_converter.py
+++ b/confluence_markdown_exporter/utils/table_converter.py
@@ -105,17 +105,17 @@ class TableConverter(MarkdownConverter):
         return text
 
     def convert_ol(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
-        if "td" in parent_tags:
+        if isinstance(parent_tags, list) and "td" in parent_tags:
             return str(el)
         return super().convert_ol(el, text, parent_tags)
 
     def convert_ul(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
-        if "td" in parent_tags:
+        if isinstance(parent_tags, list) and "td" in parent_tags:
             return str(el)
         return super().convert_ul(el, text, parent_tags)
 
     def convert_p(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
         md = super().convert_p(el, text, parent_tags)
-        if "td" in parent_tags:
+        if isinstance(parent_tags, list) and "td" in parent_tags:
             md = md.replace("\n", "") + "<br/>"
         return md

--- a/tests/unit/utils/test_table_converter.py
+++ b/tests/unit/utils/test_table_converter.py
@@ -107,3 +107,13 @@ class TestTableConverter:
         # Should have no escaped pipes
         assert "\\|" not in result
 
+    def test_convert_p_handles_non_list_parent_tags(self) -> None:
+        """convert_p should ignore non-list parent_tags values."""
+        converter = TableConverter()
+        el = BeautifulSoup("<p>text.</p>", "html.parser").p
+
+        assert el is not None
+        result = converter.convert_p(el, "text.", False)  # type: ignore[arg-type]
+
+        assert "text." in result
+

--- a/tests/unit/utils/test_table_converter.py
+++ b/tests/unit/utils/test_table_converter.py
@@ -113,7 +113,7 @@ class TestTableConverter:
         el = BeautifulSoup("<p>text.</p>", "html.parser").p
 
         assert el is not None
-        result = converter.convert_p(el, "text.", False)  # type: ignore[arg-type]
+        result = converter.convert_p(el, "text.", convert_as_inline=False)  # type: ignore[arg-type]
 
         assert "text." in result
 


### PR DESCRIPTION
Fixes #116

markdownify can pass a non-list parent_tags value, which made the td membership check crash with TypeError. This guards the table-specific checks in convert_p, convert_ol, and convert_ul so non-list values fall back to default behavior.

Added a unit test that calls convert_p with parent_tags=False to cover the reported crash path.

Greetings, saschabuehrle