### PR TITLE
fix: Space.from_url regex incorrectly matches "wiki" as space key

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -345,7 +345,7 @@ class Space(BaseModel):
 
         parsed = urllib.parse.urlparse(space_url)
         path = parsed.path.rstrip("/")
-        if match := re.search(r"(?:/wiki/spaces/|/display/|/)([A-Za-z0-9_-]+)/", path):
+        if match := re.search(r"(?:/wiki/spaces/|/display/)([A-Za-z0-9_-]+)", path):
             space_key = match.group(1)
             logger.debug("Resolved space key '%s' from URL %s", space_key, space_url)
             return cls.from_key(space_key, base_url)


### PR DESCRIPTION
## Bug

`Space.from_url()` fails for standard Confluence Cloud URLs like `https://company.atlassian.net/wiki/spaces/TEC` — it resolves the space key as `wiki` instead of `TEC`, resulting in:

```
ApiError: There is no space with the given key, or the calling user does not have permission to view the space
```

## Root Cause

The regex on line 348 has two issues:

```python
path = parsed.path.rstrip("/")
if match := re.search(r"(?:/wiki/spaces/|/display/|/)([A-Za-z0-9_-]+)/", path):
```

1. **The bare `/` alternative** (`|/`) matches the first `/` in the path, capturing `wiki` from `/wiki/spaces/TEC` instead of matching the full `/wiki/spaces/` prefix and capturing `TEC`.

2. **Trailing `/` required but stripped** — the regex requires a trailing `/` after the space key, but `rstrip("/")` on the line above always removes it.

## Fix

Remove the bare `/` alternative and the trailing `/` requirement:

```python
if match := re.search(r"(?:/wiki/spaces/|/display/)([A-Za-z0-9_-]+)", path):
```

One-line change. All standard URL formats work:
- `https://company.atlassian.net/wiki/spaces/TEC`
- `https://company.atlassian.net/wiki/spaces/TEC/`
- `https://confluence.company.com/display/MYSPACE`
- `https://company.atlassian.net/wiki/spaces/TEC/overview`