### PR TITLE
Use uvx for install and update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,15 @@ jobs:
           uv build --no-sources
           uv run --with dist/*.whl --no-project -- python -c "import confluence_markdown_exporter; print('Package imports successfully')"
 
+      - name: Update README version
+        run: |
+          sed -i "s|uvx.sh/confluence-markdown-exporter/[^/]*/install.sh|uvx.sh/confluence-markdown-exporter/${{ env.NEW_VERSION }}/install.sh|g" README.md
+
       - name: Commit version update
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add pyproject.toml uv.lock
+          git add pyproject.toml uv.lock README.md
           git commit -m "Bump version to ${{ env.NEW_VERSION }}"
           git push
 

--- a/README.md
+++ b/README.md
@@ -44,12 +44,23 @@
 
 To use the confluence-markdown-exporter, follow these steps:
 
-### 1. Installation
+### 1. Installation or Update
 
-Install python package via pip.
+Install or update confluence-markdown-exporter with a single command.
 
-```sh
-pip install confluence-markdown-exporter
+**macOS and Linux**
+```bash
+curl -LsSf uvx.sh/confluence-markdown-exporter/install.sh | sh
+```
+
+**Windows**
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://uvx.sh/confluence-markdown-exporter/install.ps1 | iex"
+```
+
+Installing a specific version
+```bash
+curl -LsSf uvx.sh/confluence-markdown-exporter/4.0.5/install.sh | sh
 ```
 
 ### 2. Exporting
@@ -556,13 +567,6 @@ CME_EXPORT__LOG_LEVEL=WARNING cme pages <page-url>
 
 This is useful for using different log levels for different environments or for scripting.
 
-## Update
-
-Update python package via pip.
-
-```sh
-pip install confluence-markdown-exporter --upgrade
-```
 
 ## Compatibility
 


### PR DESCRIPTION
## Summary

- Use uvx to install and update.
- No independent python installation needed

## Test Plan

- Only README change
