### PR TITLE
Improve windows compatibility for writing the lock file

### DIFF
--- a/confluence_markdown_exporter/utils/lockfile.py
+++ b/confluence_markdown_exporter/utils/lockfile.py
@@ -172,7 +172,14 @@ class ConfluenceLock(BaseModel):
             ) as fd:
                 tmp_path = Path(fd.name)
                 fd.write(json_str)
-            tmp_path.replace(lockfile_path)
+            try:
+                tmp_path.replace(lockfile_path)
+            except PermissionError:
+                # Windows: MoveFileExW(MOVEFILE_REPLACE_EXISTING) can fail when
+                # security software holds the destination. Fall back to non-atomic
+                # unlink + rename.
+                lockfile_path.unlink(missing_ok=True)
+                tmp_path.rename(lockfile_path)
         except BaseException:
             if tmp_path is not None:
                 tmp_path.unlink(missing_ok=True)

--- a/tests/unit/utils/test_lockfile.py
+++ b/tests/unit/utils/test_lockfile.py
@@ -573,6 +573,27 @@ class TestConfluenceLockSave:
             tmp_files = list(Path(tmp).glob("*.tmp"))
             assert tmp_files == []
 
+    def test_save_windows_permission_error_fallback(self) -> None:
+        """On Windows, PermissionError from replace falls back to unlink + rename."""
+        with tempfile.TemporaryDirectory() as tmp:
+            lockfile_path = Path(tmp) / "confluence-lock.json"
+            lock = _lock_with_pages({
+                "100": PageEntry(title="Page A", version=1, export_path="space/Page A.md"),
+            })
+
+            with patch(
+                "confluence_markdown_exporter.utils.lockfile.Path.replace",
+                side_effect=PermissionError("WinError 5"),
+            ):
+                lock.save(lockfile_path)
+
+            content = lockfile_path.read_text(encoding="utf-8")
+            data = json.loads(content)
+            pages = data["orgs"][_TEST_BASE_URL]["spaces"][_TEST_SPACE_KEY]["pages"]
+            assert "100" in pages
+            tmp_files = list(Path(tmp).glob("*.tmp"))
+            assert tmp_files == []
+
     def test_save_cleans_up_tmp_on_error(self) -> None:
         """When writing fails, no .tmp files are left behind."""
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

Windows: MoveFileExW(MOVEFILE_REPLACE_EXISTING) can fail when security software holds the destination. Fall back to non-atomic unlink + rename.

## Test Plan

Added test.
