### PR TITLE
Introduce config option for page property macros

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -976,14 +976,17 @@ class Page(Document):
 
         def convert_page_properties(
             self, el: BeautifulSoup, text: str, parent_tags: list[str]
-        ) -> None:
+        ) -> str | None:
+            if not settings.export.page_properties_as_front_matter:
+                return text
+
             rows = [
                 cast("list[Tag]", tr.find_all(["th", "td"]))
                 for tr in cast("list[Tag]", el.find_all("tr"))
                 if tr
             ]
             if not rows:
-                return
+                return None
 
             props = {
                 row[0].get_text(strip=True): self.convert(str(row[1])).strip()
@@ -992,6 +995,7 @@ class Page(Document):
             }
 
             self.set_page_properties(**props)
+            return None
 
         def convert_alert(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
             """Convert Confluence info macros to Markdown GitHub style alerts.

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -383,6 +383,17 @@ class ExportConfig(BaseModel):
         title="Page Breadcrumbs",
         description="Whether to include breadcrumb links at the top of the page.",
     )
+    page_properties_as_front_matter: bool = Field(
+        default=True,
+        title="Page Properties as Front Matter",
+        description=(
+            "Whether to convert Confluence page property tables (Page Properties macro) "
+            "into YAML front matter. "
+            "When enabled (default), the macro's key-value table is extracted and written "
+            "as YAML front matter at the top of the exported file. "
+            "When disabled, the macro is converted to a regular markdown table."
+        ),
+    )
     filename_encoding: str = Field(
         default='"<":"_",">":"_",":":"_","\\"":"_","/":"_","\\\\":"_","|":"_","?":"_","*":"_","\\u0000":"_","[":"_","]":"_","\'":"_","’":"_","´":"_","`":"_"',  # noqa: RUF001
         title="Filename Encoding",


### PR DESCRIPTION
## Summary

Currently page property macros are always converted to markdown front matter. This might not always be desired. This feature adds a config option to disable this convertion and instead just output the page property tables as regular tables.

## Test Plan

Manually tested.
