### PR TITLE
Remove extension from attachment title

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ It generally was tested on:
 
 ## Known Issues and Limitations
 
-1. **Missing Attachment File ID on Server**: For some Confluence Server version/configuration the attachment file ID might not be provided (https://github.com/Spenhouet/confluence-markdown-exporter/issues/39). In the default configuration, this is used for the export path. Solution: Adjust the attachment path in the export config and use the `{attachment_id}` or `{attachment_title}` instead.
+1. **Missing Attachment File ID on Server**: For some Confluence Server version/configuration the attachment file ID might not be provided (https://github.com/Spenhouet/confluence-markdown-exporter/issues/39). In the default configuration, this is used for the export path. Solution: Adjust the attachment path in the export config and use the `{attachment_id}` or `{attachment_title}{attachment_extension}` instead.
 2. **Connection Issues when behind Proxy or VPN**: There might be connection issues if your Confluence Server is behind a proxy or VPN (https://github.com/Spenhouet/confluence-markdown-exporter/issues/38). If you experience issues, help to fix this is appreciated.
 
 ## Contributing

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -464,10 +464,13 @@ class Attachment(Document):
 
     @property
     def _template_vars(self) -> dict[str, str]:
+        ext = self.extension
+        title = self.title
+        title_without_ext = title[: -len(ext)] if ext and title.endswith(ext) else Path(title).stem
         return {
             **super()._template_vars,
             "attachment_id": str(self.id),
-            "attachment_title": sanitize_filename(self.title),
+            "attachment_title": sanitize_filename(title_without_ext),
             # file_id is a GUID and does not need sanitized.
             "attachment_file_id": self.file_id,
             "attachment_extension": self.extension,

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -11,6 +11,7 @@ from pydantic import Field
 from pydantic import SecretStr
 from pydantic import ValidationError
 from pydantic import field_serializer
+from pydantic import field_validator
 from pydantic import model_validator
 from pydantic_settings import BaseSettings
 from pydantic_settings import PydanticBaseSettingsSource
@@ -362,13 +363,31 @@ class ExportConfig(BaseModel):
             "  - {ancestor_ids}: A slash-separated list of ancestor page IDs.\n"
             "  - {ancestor_titles}: A slash-separated list of ancestor page titles.\n"
             "  - {attachment_id}: The unique ID of the attachment.\n"
-            "  - {attachment_title}: The title of the attachment.\n"
+            "  - {attachment_title}: The title of the attachment (without file extension).\n"
             "  - {attachment_file_id}: The file ID of the attachment.\n"
             "  - {attachment_extension}: The file extension of the attachment,\n"
             "including the leading dot."
         ),
         examples=["{space_name}/attachments/{attachment_file_id}{attachment_extension}"],
     )
+
+    @field_validator("attachment_path", mode="before")
+    @classmethod
+    def _migrate_attachment_path(cls, v: object) -> object:
+        """Migrate templates that used {attachment_title} as the full filename.
+
+        Before this change, {attachment_title} included the file extension.
+        Templates that relied on that (i.e. no explicit {attachment_extension})
+        are silently updated so file extensions are preserved.
+        """
+        if (
+            isinstance(v, str)
+            and "{attachment_title}" in v
+            and "{attachment_extension}" not in v
+        ):
+            return v.replace("{attachment_title}", "{attachment_title}{attachment_extension}")
+        return v
+
     attachment_export_all: bool = Field(
         default=False,
         title="Attachment Export All",

--- a/tests/unit/utils/test_app_data_store_env.py
+++ b/tests/unit/utils/test_app_data_store_env.py
@@ -9,6 +9,7 @@ import pytest
 
 from confluence_markdown_exporter.utils.app_data_store import AppSettings
 from confluence_markdown_exporter.utils.app_data_store import ConfigModel
+from confluence_markdown_exporter.utils.app_data_store import ExportConfig
 from confluence_markdown_exporter.utils.app_data_store import get_settings
 
 
@@ -180,3 +181,40 @@ class TestEnvVarOverrides:
             ValidationError
         ):
             get_settings()
+
+
+class TestAttachmentPathMigration:
+    """Test migration of attachment_path templates that omit {attachment_extension}."""
+
+    def test_title_without_extension_gets_migrated(self) -> None:
+        """{attachment_title} alone is migrated to include {attachment_extension}."""
+        config = ExportConfig(attachment_path="{space_name}/{attachment_title}")
+        assert config.attachment_path == "{space_name}/{attachment_title}{attachment_extension}"
+
+    def test_title_with_other_path_segments_migrated(self) -> None:
+        """Migration works regardless of surrounding path segments."""
+        config = ExportConfig(attachment_path="{page_title}/{attachment_title}")
+        assert config.attachment_path == "{page_title}/{attachment_title}{attachment_extension}"
+
+    def test_title_already_has_extension_not_changed(self) -> None:
+        """Template already containing {attachment_extension} is left unchanged."""
+        original = "{space_name}/{attachment_title}{attachment_extension}"
+        config = ExportConfig(attachment_path=original)
+        assert config.attachment_path == original
+
+    def test_no_attachment_title_not_changed(self) -> None:
+        """Default template without {attachment_title} is left unchanged."""
+        original = "{space_name}/attachments/{attachment_file_id}{attachment_extension}"
+        config = ExportConfig(attachment_path=original)
+        assert config.attachment_path == original
+
+    def test_migration_via_env_var(self) -> None:
+        """Migration also applies when the template comes from an ENV var."""
+        with patch.dict(
+            os.environ,
+            {"CME_EXPORT__ATTACHMENT_PATH": "{space_name}/attachments/{attachment_title}"},
+        ):
+            settings = get_settings()
+        assert settings.export.attachment_path == (
+            "{space_name}/attachments/{attachment_title}{attachment_extension}"
+        )


### PR DESCRIPTION
## Summary

Attachment title contained the extension which limited consistency in the export path config.

## Test Plan

Test for migration are added.