### PR TITLE
Support Emoticons

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -16,6 +16,7 @@ from concurrent.futures import as_completed
 from os import PathLike
 from pathlib import Path
 from string import Template
+from typing import ClassVar
 from typing import Literal
 from typing import TypeAlias
 from typing import cast
@@ -1326,7 +1327,52 @@ class Page(Document):
 
             return md
 
-        def convert_img(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:  # noqa: C901
+        _ATLASSIAN_EMOTICONS: ClassVar[dict[str, str]] = {
+            "atlassian-check_mark": "✅",
+            "atlassian-cross_mark": "❌",
+            "atlassian-yes": "👍",
+            "atlassian-no": "👎",
+            "atlassian-information": "\u2139\ufe0f",
+            "atlassian-warning": "⚠️",
+            "atlassian-forbidden": "🚫",
+            "atlassian-plus": "\u2795",
+            "atlassian-minus": "\u2796",
+            "atlassian-question": "❓",
+            "atlassian-exclamation": "❗",
+            "atlassian-light_on": "💡",
+            "atlassian-light_off": "💡",
+            "atlassian-star_yellow": "⭐",
+            "atlassian-blue_star": "🔵",
+            "atlassian-smile": "😊",
+            "atlassian-sad": "😞",
+            "atlassian-tongue": "😛",
+            "atlassian-biggrin": "😁",
+            "atlassian-wink": "😉",
+        }
+
+        def _convert_emoticon(self, el: BeautifulSoup) -> str | None:
+            classes = el.get("class") or []
+            if "emoticon" not in classes:
+                return None
+            emoji_id = str(el.get("data-emoji-id", ""))
+            fallback = str(el.get("data-emoji-fallback", ""))
+            if fallback and not fallback.startswith(":"):
+                return fallback
+            if emoji_id:
+                try:
+                    codepoints = [int(cp, 16) for cp in emoji_id.split("-")]
+                    return "".join(chr(cp) for cp in codepoints)
+                except ValueError:
+                    pass
+                if emoji_id in self._ATLASSIAN_EMOTICONS:
+                    return self._ATLASSIAN_EMOTICONS[emoji_id]
+            shortname = str(el.get("data-emoji-shortname", ""))
+            return shortname or str(el.get("alt", "")) or None
+
+        def convert_img(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:  # noqa: C901, PLR0911, PLR0912
+            if emoticon := self._convert_emoticon(el):
+                return emoticon
+
             attachment = None
             if fid := el.get("data-media-id"):
                 attachment = self.page.get_attachment_by_file_id(str(fid))

--- a/tests/unit/test_emoticon_conversion.py
+++ b/tests/unit/test_emoticon_conversion.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def converter() -> "Page.Converter":
+def converter() -> Page.Converter:
     from confluence_markdown_exporter.confluence import Page
 
     class MockPage:
@@ -29,30 +29,58 @@ def converter() -> "Page.Converter":
 
 
 class TestEmoticonConversion:
-    def test_atlassian_check_mark(self, converter: "Page.Converter") -> None:
-        html = '<img class="emoticon emoticon-tick" data-emoji-id="atlassian-check_mark" data-emoji-fallback=":check_mark:" data-emoji-shortname=":check_mark:" alt="(tick)" />'
+    def test_atlassian_check_mark(self, converter: Page.Converter) -> None:
+        html = (
+            '<img class="emoticon emoticon-tick"'
+            ' data-emoji-id="atlassian-check_mark"'
+            ' data-emoji-fallback=":check_mark:"'
+            ' data-emoji-shortname=":check_mark:"'
+            ' alt="(tick)" />'
+        )
         assert converter.convert(html).strip() == "✅"
 
-    def test_atlassian_cross_mark(self, converter: "Page.Converter") -> None:
-        html = '<img class="emoticon emoticon-cross" data-emoji-id="atlassian-cross_mark" data-emoji-fallback=":cross_mark:" data-emoji-shortname=":cross_mark:" alt="(error)" />'
+    def test_atlassian_cross_mark(self, converter: Page.Converter) -> None:
+        html = (
+            '<img class="emoticon emoticon-cross"'
+            ' data-emoji-id="atlassian-cross_mark"'
+            ' data-emoji-fallback=":cross_mark:"'
+            ' data-emoji-shortname=":cross_mark:"'
+            ' alt="(error)" />'
+        )
         assert converter.convert(html).strip() == "❌"
 
-    def test_unicode_emoji_by_hex_id(self, converter: "Page.Converter") -> None:
-        html = '<img class="emoticon emoticon-blue-star" data-emoji-id="1f6e0" data-emoji-fallback="\U0001f6e0️" data-emoji-shortname=":tools:" alt="(blue star)" />'
+    def test_unicode_emoji_by_hex_id(self, converter: Page.Converter) -> None:
+        html = (
+            '<img class="emoticon emoticon-blue-star"'
+            ' data-emoji-id="1f6e0"'
+            ' data-emoji-fallback="\U0001f6e0️"'
+            ' data-emoji-shortname=":tools:"'
+            ' alt="(blue star)" />'
+        )
         assert converter.convert(html).strip() == "\U0001f6e0️"
 
-    def test_unicode_emoji_fallback_direct(self, converter: "Page.Converter") -> None:
-        html = '<img class="emoticon" data-emoji-id="1f600" data-emoji-fallback="\U0001f600" alt="smile" />'
+    def test_unicode_emoji_fallback_direct(self, converter: Page.Converter) -> None:
+        html = (
+            '<img class="emoticon"'
+            ' data-emoji-id="1f600"'
+            ' data-emoji-fallback="\U0001f600"'
+            ' alt="smile" />'
+        )
         assert converter.convert(html).strip() == "\U0001f600"
 
-    def test_non_emoticon_img_unchanged(self, converter: "Page.Converter") -> None:
+    def test_non_emoticon_img_unchanged(self, converter: Page.Converter) -> None:
         html = '<img src="http://example.com/image.png" alt="photo" />'
         result = converter.convert(html).strip()
         assert "emoticon" not in result
         assert "example.com" in result
 
-    def test_emoticon_inline_in_text(self, converter: "Page.Converter") -> None:
-        html = 'Status: <img class="emoticon emoticon-tick" data-emoji-id="atlassian-check_mark" data-emoji-fallback=":check_mark:" alt="(tick)" /> Done'
+    def test_emoticon_inline_in_text(self, converter: Page.Converter) -> None:
+        html = (
+            'Status: <img class="emoticon emoticon-tick"'
+            ' data-emoji-id="atlassian-check_mark"'
+            ' data-emoji-fallback=":check_mark:"'
+            ' alt="(tick)" /> Done'
+        )
         result = converter.convert(html).strip()
         assert "✅" in result
         assert "Done" in result

--- a/tests/unit/test_emoticon_conversion.py
+++ b/tests/unit/test_emoticon_conversion.py
@@ -1,0 +1,58 @@
+"""Test that Confluence emoticon img tags are converted to unicode emoji."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from confluence_markdown_exporter.confluence import Page
+
+
+@pytest.fixture
+def converter() -> "Page.Converter":
+    from confluence_markdown_exporter.confluence import Page
+
+    class MockPage:
+        def __init__(self) -> None:
+            self.id = "test-page"
+            self.title = "Test Page"
+            self.html = ""
+            self.labels = []
+            self.ancestors = []
+
+        def get_attachment_by_file_id(self, file_id: str) -> None:
+            return None
+
+    return Page.Converter(MockPage())
+
+
+class TestEmoticonConversion:
+    def test_atlassian_check_mark(self, converter: "Page.Converter") -> None:
+        html = '<img class="emoticon emoticon-tick" data-emoji-id="atlassian-check_mark" data-emoji-fallback=":check_mark:" data-emoji-shortname=":check_mark:" alt="(tick)" />'
+        assert converter.convert(html).strip() == "✅"
+
+    def test_atlassian_cross_mark(self, converter: "Page.Converter") -> None:
+        html = '<img class="emoticon emoticon-cross" data-emoji-id="atlassian-cross_mark" data-emoji-fallback=":cross_mark:" data-emoji-shortname=":cross_mark:" alt="(error)" />'
+        assert converter.convert(html).strip() == "❌"
+
+    def test_unicode_emoji_by_hex_id(self, converter: "Page.Converter") -> None:
+        html = '<img class="emoticon emoticon-blue-star" data-emoji-id="1f6e0" data-emoji-fallback="\U0001f6e0️" data-emoji-shortname=":tools:" alt="(blue star)" />'
+        assert converter.convert(html).strip() == "\U0001f6e0️"
+
+    def test_unicode_emoji_fallback_direct(self, converter: "Page.Converter") -> None:
+        html = '<img class="emoticon" data-emoji-id="1f600" data-emoji-fallback="\U0001f600" alt="smile" />'
+        assert converter.convert(html).strip() == "\U0001f600"
+
+    def test_non_emoticon_img_unchanged(self, converter: "Page.Converter") -> None:
+        html = '<img src="http://example.com/image.png" alt="photo" />'
+        result = converter.convert(html).strip()
+        assert "emoticon" not in result
+        assert "example.com" in result
+
+    def test_emoticon_inline_in_text(self, converter: "Page.Converter") -> None:
+        html = 'Status: <img class="emoticon emoticon-tick" data-emoji-id="atlassian-check_mark" data-emoji-fallback=":check_mark:" alt="(tick)" /> Done'
+        result = converter.convert(html).strip()
+        assert "✅" in result
+        assert "Done" in result


### PR DESCRIPTION
## Summary

Confluence provides "Emoticons" to include in pages.

Currently an emoji like ":check_mark:" is exportet as ![](/wiki/s/-1959019322/6452/939cc67b5487c076abcac2578a93998e47ca8e0b/_/images/icons/emoticons/check.png) or ":cross_mark:" as ![](/wiki/s/-1959019322/6452/939cc67b5487c076abcac2578a93998e47ca8e0b/_/images/icons/emoticons/error.png).

Instead we convert to unicode or similar.

## Test Plan

Tests are added.
