### PR TITLE
Implement fallback for corrupt config file

### DIFF
--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -1,5 +1,6 @@
 """Handles storage and retrieval of application data (auth and settings) for the exporter."""
 
+import contextlib
 import json
 import os
 from pathlib import Path
@@ -554,7 +555,10 @@ class AppSettings(BaseSettings):
 
 def load_app_data() -> dict[str, dict]:
     """Load application data from the config file, returning a validated dict."""
-    data = json.loads(APP_CONFIG_PATH.read_text()) if APP_CONFIG_PATH.exists() else {}
+    data: dict = {}
+    if APP_CONFIG_PATH.exists():
+        with contextlib.suppress(json.JSONDecodeError, ValueError):
+            data = json.loads(APP_CONFIG_PATH.read_text())
     try:
         return ConfigModel(**data).model_dump()
     except ValidationError:

--- a/tests/unit/utils/test_app_data_store_env.py
+++ b/tests/unit/utils/test_app_data_store_env.py
@@ -11,6 +11,7 @@ from confluence_markdown_exporter.utils.app_data_store import AppSettings
 from confluence_markdown_exporter.utils.app_data_store import ConfigModel
 from confluence_markdown_exporter.utils.app_data_store import ExportConfig
 from confluence_markdown_exporter.utils.app_data_store import get_settings
+from confluence_markdown_exporter.utils.app_data_store import load_app_data
 
 
 class TestEnvVarOverrides:
@@ -181,6 +182,30 @@ class TestEnvVarOverrides:
             ValidationError
         ):
             get_settings()
+
+
+class TestLoadAppData:
+    """Tests for load_app_data robustness."""
+
+    def test_empty_config_file_returns_defaults(self) -> None:
+        """Empty config file must not raise JSONDecodeError."""
+        import confluence_markdown_exporter.utils.app_data_store as ads
+
+        with patch.object(ads, "APP_CONFIG_PATH") as mock_path:
+            mock_path.exists.return_value = True
+            mock_path.read_text.return_value = ""
+            result = load_app_data()
+        assert isinstance(result, dict)
+
+    def test_invalid_json_config_file_returns_defaults(self) -> None:
+        """Corrupt config file must not raise JSONDecodeError."""
+        import confluence_markdown_exporter.utils.app_data_store as ads
+
+        with patch.object(ads, "APP_CONFIG_PATH") as mock_path:
+            mock_path.exists.return_value = True
+            mock_path.read_text.return_value = "not json {"
+            result = load_app_data()
+        assert isinstance(result, dict)
 
 
 class TestAttachmentPathMigration:


### PR DESCRIPTION
## Summary

When the loaded config file is corrupted the error message is directly forwarded to the user. Which isn't helpful as reported in #190.

When a corrupted config file is detected we fallback to default config.

## Test Plan

Tests added.
