### PR TITLE
Fix custom Confluence emoji UUID conversion

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -69,6 +69,7 @@ JsonResponse: TypeAlias = dict
 StrPath: TypeAlias = str | PathLike[str]
 
 logger = logging.getLogger(__name__)
+_MAX_UNICODE_CODEPOINT = 0x10FFFF
 
 
 def _require_dict(response: object, context: str) -> JsonResponse:
@@ -1523,13 +1524,14 @@ class Page(Document):
             if emoji_id:
                 try:
                     codepoints = [int(cp, 16) for cp in emoji_id.split("-")]
-                    return "".join(chr(cp) for cp in codepoints)
-                except ValueError:
+                    if all(0 <= cp <= _MAX_UNICODE_CODEPOINT for cp in codepoints):
+                        return "".join(chr(cp) for cp in codepoints)
+                except (OverflowError, ValueError):
                     pass
                 if emoji_id in self._ATLASSIAN_EMOTICONS:
                     return self._ATLASSIAN_EMOTICONS[emoji_id]
             shortname = str(el.get("data-emoji-shortname", ""))
-            return shortname or str(el.get("alt", "")) or None
+            return shortname or fallback or str(el.get("alt", "")) or None
 
         def convert_img(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:  # noqa: C901, PLR0911, PLR0912
             if emoticon := self._convert_emoticon(el):

--- a/tests/unit/test_emoticon_conversion.py
+++ b/tests/unit/test_emoticon_conversion.py
@@ -68,6 +68,16 @@ class TestEmoticonConversion:
         )
         assert converter.convert(html).strip() == "\U0001f600"
 
+    def test_custom_emoji_uuid_falls_back_to_shortname(self, converter: Page.Converter) -> None:
+        html = (
+            '<img class="emoticon emoticon-blue-star"'
+            ' data-emoji-id="fb5b359f-23fa-44bd-872b-676e207eaaef"'
+            ' data-emoji-fallback=":alert-1:"'
+            ' data-emoji-shortname=":alert-1:"'
+            ' alt="(blue star)" />'
+        )
+        assert converter.convert(html).strip() == ":alert-1:"
+
     def test_non_emoticon_img_unchanged(self, converter: Page.Converter) -> None:
         html = '<img src="http://example.com/image.png" alt="photo" />'
         result = converter.convert(html).strip()


### PR DESCRIPTION
## Summary
- avoid treating UUID-style `data-emoji-id` values as Unicode code points
- fall back to `data-emoji-shortname`/`data-emoji-fallback` for custom Confluence emojis
- add a regression test covering UUID-based custom emojis

## Why
Some Confluence pages use custom emojis whose `data-emoji-id` is a UUID like `fb5b359f-23fa-44bd-872b-676e207eaaef` rather than a Unicode code point sequence. The exporter currently splits on `-`, parses each part as hex, and passes the result to `chr(...)`, which can raise `OverflowError` or `ValueError` and abort page export.

This change only converts `data-emoji-id` values when all parsed values are valid Unicode code points, and otherwise falls back to the shortname/fallback text so export can continue.

Resolves #202 