### PR TITLE
fix: support personal space keys starting with ~ in cloud URL parser

### DIFF
--- a/confluence_markdown_exporter/api_clients.py
+++ b/confluence_markdown_exporter/api_clients.py
@@ -105,7 +105,7 @@ class ConfluenceRef(BaseModel):
 # 1) Cloud [/wiki]/spaces/{space_key}[/pages/{page_id}[/{page_title}]]
 _CLOUD_URL_RE = re.compile(
     r"^(?:/ex/confluence/[^/]+)?(?:/wiki)?/spaces/"
-    r"(?P<space_key>[A-Za-z0-9_-]+)"
+    r"(?P<space_key>[A-Za-z0-9_~-]+)"
     r"(?:/pages/(?P<page_id>\d+)(?:/(?P<page_title>[^/?#]+))?)?"
     r"(?:/(?!pages/)[^/?#]+)?/?$"
 )


### PR DESCRIPTION
## Summary

- Confluence personal spaces use a tilde-prefixed key (e.g. `~username`)
- `_CLOUD_URL_RE` excluded `~` from the `space_key` character class, causing URLs like `/wiki/spaces/~myname/pages/123` to fail parsing
- Added `~` to the character class: `[A-Za-z0-9_-]+` → `[A-Za-z0-9_~-]+`

## Test plan

- [ ] All 253 existing tests pass (`uv run pytest`)
- [ ] Ruff linting clean (`uv run ruff check`)
- [ ] Manually verify a personal space URL parses correctly