### PR TITLE
Add optional Confluence page URL to exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,13 @@ Whether to include breadcrumb links at the top of the page.
 - Default: `True`
 - ENV Var: `CME_EXPORT__PAGE_BREADCRUMBS`
 
+##### export.include_confluence_page_url
+
+Whether to include the original Confluence page URL at the top of the exported markdown file.
+
+- Default: `False`
+- ENV Var: `CME_EXPORT__INCLUDE_CONFLUENCE_PAGE_URL`
+
 ##### export.page_properties_as_front_matter
 
 Whether to convert Confluence Page Properties macro tables into YAML front matter. When enabled, key-value pairs in the macro are extracted and written as YAML front matter at the top of the exported file. When disabled, the macro is converted to a regular markdown table.

--- a/confluence_markdown_exporter/config.py
+++ b/confluence_markdown_exporter/config.py
@@ -32,6 +32,8 @@ _CONFIG_KEYS_EPILOG = (
     "| `export.attachment_href` | Link style for attachments: `relative` or `absolute` |\n\n"
     "| `export.include_document_title` | Prepend H1 title to each page |\n\n"
     "| `export.page_breadcrumbs` | Include breadcrumb links at top of page |\n\n"
+    "| `export.include_confluence_page_url` | Include original Confluence page URL "
+    "at top of page |\n\n"
     "| `export.enable_jira_enrichment` | Fetch Jira data for enriched links |\n\n"
     "| `export.attachment_export_all` | Export all attachments, not only referenced ones |\n\n"
     "| `export.filename_length` | Maximum filename length (default: 255) |\n\n"

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -144,6 +144,25 @@ def _extract_base_url(url: str) -> str:
     return normalize_instance_url(base)
 
 
+def _get_web_url(data: JsonResponse) -> str:
+    links = data.get("_links", {})
+    if not isinstance(links, dict):
+        return ""
+
+    base = links.get("base")
+    webui = links.get("webui")
+
+    if not isinstance(base, str) or not isinstance(webui, str):
+        return ""
+
+    base = base.rstrip("/")
+    webui = webui.lstrip("/")
+    if (not base) or (not webui):
+        return ""
+
+    return f"{base}/{webui}"
+
+
 _JIRA_ROUTE_SEGMENTS = {
     "agile",
     "backlog",
@@ -765,6 +784,7 @@ class Descendant(Document):
 
 class Page(Document):
     id: int
+    web_url: str = ""
     body: str
     body_export: str
     editor2: str
@@ -960,6 +980,7 @@ class Page(Document):
     def from_json(cls, data: JsonResponse, base_url: str) -> "Page":
         return cls(
             base_url=base_url,
+            web_url=_get_web_url(data),
             id=data.get("id", 0),
             title=data.get("title", ""),
             space=Space.from_key(
@@ -1104,6 +1125,9 @@ class Page(Document):
             md_body = self.convert(self.page.html)
             md_body = self._escape_template_placeholders(md_body)
             markdown = f"{self.front_matter}\n"
+            include_web_url = getattr(settings.export, "include_confluence_page_url", False)
+            if isinstance(include_web_url, bool) and include_web_url and self.page.web_url:
+                markdown += f"Confluence page: {self.page.web_url}\n\n"
             if settings.export.page_breadcrumbs:
                 markdown += f"{self.breadcrumbs}\n"
             markdown += f"{md_body}\n"

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -413,6 +413,14 @@ class ExportConfig(BaseModel):
         title="Page Breadcrumbs",
         description="Whether to include breadcrumb links at the top of the page.",
     )
+    include_confluence_page_url: bool = Field(
+        default=False,
+        title="Include Confluence Page URL",
+        description=(
+            "Whether to include the original Confluence page URL at the top of the "
+            "exported markdown file."
+        ),
+    )
     page_properties_as_front_matter: bool = Field(
         default=True,
         title="Page Properties as Front Matter",

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from confluence_markdown_exporter.confluence import Page
+from confluence_markdown_exporter.confluence import _get_web_url
 
 
 class MockPage:
@@ -16,6 +17,7 @@ class MockPage:
         self.id = "test-page"
         self.title = "Test Page"
         self.html = ""
+        self.web_url = "https://example.atlassian.net/wiki/spaces/TEST/pages/123/Test+Page"
         self.labels = []
         self.ancestors = []
 
@@ -58,6 +60,39 @@ class TestAnchorLinkConversion:
             html = '<a href="#1.-Request-Service">Request Service</a>'
             result = converter.convert(html).strip()
         assert result == "[[#Request Service]]"
+
+
+class TestPageWebUrl:
+    """Original Confluence page URL handling."""
+
+    def test_get_web_url_combines_base_and_webui(self) -> None:
+        data = {
+            "_links": {
+                "base": "https://example.atlassian.net/wiki",
+                "webui": "/spaces/TEST/pages/123/Test+Page",
+            }
+        }
+
+        assert _get_web_url(data) == (
+            "https://example.atlassian.net/wiki/spaces/TEST/pages/123/Test+Page"
+        )
+
+    def test_get_web_url_returns_empty_string_when_links_are_missing(self) -> None:
+        assert _get_web_url({}) == ""
+
+    def test_markdown_includes_web_url_when_enabled(self) -> None:
+        page = MockPage()
+        page.html = "<p>Hello</p>"
+
+        with patch("confluence_markdown_exporter.confluence.settings") as mock_settings:
+            mock_settings.export.include_confluence_page_url = True
+            mock_settings.export.page_breadcrumbs = False
+            result = Page.Converter(page).markdown
+
+        assert (
+            "Confluence page: "
+            "https://example.atlassian.net/wiki/spaces/TEST/pages/123/Test+Page"
+        ) in result
 
 
 class TestPageFromUrl:

--- a/tests/unit/utils/test_app_data_store_env.py
+++ b/tests/unit/utils/test_app_data_store_env.py
@@ -53,6 +53,12 @@ class TestEnvVarOverrides:
             settings = get_settings()
         assert settings.export.attachment_export_all is True
 
+    def test_include_confluence_page_url_env_override(self) -> None:
+        """CME_EXPORT__INCLUDE_CONFLUENCE_PAGE_URL=true includes source page URL."""
+        with patch.dict(os.environ, {"CME_EXPORT__INCLUDE_CONFLUENCE_PAGE_URL": "true"}):
+            settings = get_settings()
+        assert settings.export.include_confluence_page_url is True
+
     def test_env_var_does_not_persist(self) -> None:
         """ENV var override is session-only and does not alter the JSON config file."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Refs #150

## Summary

Adds attempt to build the Confluence URL from the Confluence API response's `_links.base` and `_links.webui` for all Page instantiations

Adds an optional export setting, `export.include_confluence_page_url`, that includes original Confluence URL in the exported md file like so:

    Confluence page: https://...

The setting defaults to `false` and has documentation.

Adds unit tests.

## Test Plan

- `uv run pytest`
- `uv run ruff check'
- Manual test: 
  - enabled `export.include_confluence_page_url`
  - manually exported a Confluence page, space, and org
  - verified exported Markdown files include the original Confluence page URL