### PR TITLE
fix: skip v1 connection ping when cloud_id is set

### DIFF
--- a/confluence_markdown_exporter/api_clients.py
+++ b/confluence_markdown_exporter/api_clients.py
@@ -197,7 +197,12 @@ class ApiClientFactory:
                 token=auth.pat.get_secret_value() if auth.pat else None,
                 **self.connection_config.model_dump(),
             )
-            instance.get_all_spaces(limit=1)
+            # Skip the v1 /rest/api/space ping when routing through the
+            # Atlassian API gateway: Cloud has removed that endpoint
+            # (HTTP 410 Gone) and scoped tokens reject v1 calls outright
+            # with 401. Real export calls surface auth errors naturally.
+            if not auth.cloud_id:
+                instance.get_all_spaces(limit=1)
         except Exception as e:
             msg = f"Confluence connection failed: {e}"
             raise ConnectionError(msg) from e
@@ -212,7 +217,10 @@ class ApiClientFactory:
                 token=auth.pat.get_secret_value() if auth.pat else None,
                 **self.connection_config.model_dump(),
             )
-            instance.get_all_projects()
+            # See create_confluence: skip the v1 /rest/api/project ping
+            # when routing through the Atlassian API gateway.
+            if not auth.cloud_id:
+                instance.get_all_projects()
         except Exception as e:
             msg = f"Jira connection failed: {e}"
             raise ConnectionError(msg) from e

--- a/tests/unit/test_api_clients.py
+++ b/tests/unit/test_api_clients.py
@@ -257,6 +257,46 @@ class TestApiClientFactory:
         with pytest.raises(ConnectionError, match="Jira connection failed"):
             factory.create_jira(SAMPLE_CONFLUENCE_URL, sample_api_details)
 
+    @patch("confluence_markdown_exporter.api_clients.ConfluenceApiSdk")
+    def test_create_confluence_skips_v1_validation_when_cloud_id_set(
+        self, mock_confluence_sdk: MagicMock, sample_api_details: ApiDetails
+    ) -> None:
+        """When auth.cloud_id is set, skip the v1 /rest/api/space ping.
+
+        Cloud has removed that endpoint (HTTP 410); scoped tokens reject
+        v1 calls with 401. Real export calls surface auth errors naturally.
+        """
+        mock_instance = MagicMock()
+        mock_confluence_sdk.return_value = mock_instance
+
+        cloud_auth = sample_api_details.model_copy(
+            update={"cloud_id": "00000000-0000-0000-0000-000000000000"}
+        )
+        factory = ApiClientFactory(AtlassianSdkConnectionConfig())
+
+        result = factory.create_confluence(SAMPLE_CONFLUENCE_URL, cloud_auth)
+
+        assert result == mock_instance
+        mock_instance.get_all_spaces.assert_not_called()
+
+    @patch("confluence_markdown_exporter.api_clients.JiraApiSdk")
+    def test_create_jira_skips_v1_validation_when_cloud_id_set(
+        self, mock_jira_sdk: MagicMock, sample_api_details: ApiDetails
+    ) -> None:
+        """When auth.cloud_id is set, skip the v1 /rest/api/project ping."""
+        mock_instance = MagicMock()
+        mock_jira_sdk.return_value = mock_instance
+
+        cloud_auth = sample_api_details.model_copy(
+            update={"cloud_id": "00000000-0000-0000-0000-000000000000"}
+        )
+        factory = ApiClientFactory(AtlassianSdkConnectionConfig())
+
+        result = factory.create_jira(SAMPLE_CONFLUENCE_URL, cloud_auth)
+
+        assert result == mock_instance
+        mock_instance.get_all_projects.assert_not_called()
+
 
 class TestGetConfluenceInstance:
     """Test cases for get_confluence_instance function."""
@@ -334,9 +374,7 @@ class TestAuthConfigContextPath:
             ("https://host.example.com:8443", "https://host.example.com:8443/confluence"),
         ],
     )
-    def test_get_instance_matches_context_path_url(
-        self, stored_key: str, lookup_url: str
-    ) -> None:
+    def test_get_instance_matches_context_path_url(self, stored_key: str, lookup_url: str) -> None:
         config = self._make_config(stored_key)
         assert config.get_instance(lookup_url) is not None
 


### PR DESCRIPTION
Closes #207.

`create_confluence` and `create_jira` validate new clients with `get_all_spaces` / `get_all_projects`, which hit v1 `/rest/api/space` and `/rest/api/project`. When `auth.cloud_id` is set, cme constructs the SDK base URL as `https://api.atlassian.com/ex/confluence/{cloud_id}` (`_get_confluence_sdk_url`, [api_clients.py L79-L83](https://github.com/Spenhouet/confluence-markdown-exporter/blob/main/confluence_markdown_exporter/api_clients.py#L79-L83)); on my Cloud setup the resulting v1 path returns HTTP 410, validation fails, and the `AuthNotConfiguredError` re-opens the interactive editor — which crashes in non-TTY environments.

When `auth.cloud_id` is set, skip the ping. Real export calls surface auth errors naturally on the first request.

### Tests

```
$ uv run pytest --quiet
255 passed in 3.76s

$ uv run pytest tests/unit/test_api_clients.py -v
...
test_create_confluence_success ............................... PASSED
test_create_confluence_connection_failure .................... PASSED
test_create_jira_success ..................................... PASSED
test_create_jira_connection_failure .......................... PASSED
test_create_confluence_skips_v1_validation_when_cloud_id_set . PASSED
test_create_jira_skips_v1_validation_when_cloud_id_set ....... PASSED
```

### End-to-end against a Cloud tenant (sanitized)

Same auth that previously hit the interactive editor on every command:

```
$ cme page "https://example.atlassian.net/wiki/spaces/X/pages/123456789/Page+Title"
[time] INFO     Connected to Confluence at
                https://api.atlassian.com/ex/confluence/00000000-0000-0000-0000-000000000000
[time] WARNING  Could not access page id=123456789 — treating as inaccessible
[time] WARNING  Skipping export for inaccessible page id=123456789
✓ Export pages ... completed in 0s
```

The validation step now passes (`Connected to Confluence at <gateway>`). The downstream "page inaccessible" warning is the second wrinkle from #207 — cme's content-fetch path uses v1 endpoints that scoped tokens 401 on. That's a separate change; this PR is just the unblocker so users with `cloud_id` set can get past validation without the interactive editor crashing in non-TTY environments.

Implements option **A** from #207.
