### PR TITLE
Properly format bullet list in table cells

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1242,6 +1242,14 @@ class Page(Document):
                 if el["data-macro-name"] == "jira":
                     return self.convert_jira_issue(el, text, parent_tags)
 
+            if el.has_attr("class") and "inline-comment-marker" in el["class"]:
+                return self.convert_inline_comment_marker(el, text, parent_tags)
+
+            return text
+
+        def convert_inline_comment_marker(
+            self, _el: BeautifulSoup, text: str, _parent_tags: list[str]
+        ) -> str:
             return text
 
         def convert_attachments(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:

--- a/confluence_markdown_exporter/utils/table_converter.py
+++ b/confluence_markdown_exporter/utils/table_converter.py
@@ -121,12 +121,23 @@ class TableConverter(MarkdownConverter):
             return str(el)
         return super().convert_ol(el, text, tags)
 
+    def convert_li(
+        self, el: BeautifulSoup, text: str, parent_tags: "TableConverter.ParentTags | bool"
+    ) -> str:
+        tags = self._normalize_parent_tags(parent_tags)
+        if "td" in tags:
+            return text.strip().removesuffix("<br/>") + "\n"
+        return MarkdownConverter.convert_li(self, el, text, tags)  # type: ignore[attr-defined]
+
     def convert_ul(
         self, el: BeautifulSoup, text: str, parent_tags: "TableConverter.ParentTags | bool"
     ) -> str:
         tags = self._normalize_parent_tags(parent_tags)
         if "td" in tags:
-            return str(el)
+            items = [item for item in text.splitlines() if item.strip()]
+            if not items:
+                return ""
+            return "- " + "<br>- ".join(items)
         return super().convert_ul(el, text, tags)
 
     def convert_p(


### PR DESCRIPTION
## Summary

Currently bullet lists are just inserted as plain HTML. This isn't very clean and can also include some other HTML parts. Instead we now use `<br/>- ` for bullet points.

## Test Plan

Manually tested.
