### PR TITLE
Feature/simplify output

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1462,6 +1462,8 @@ class Page(Document):
             self, el: BeautifulSoup, text: str, parent_tags: list[str]
         ) -> str:
             content = super().convert_p(el, text, parent_tags)
+            if not content.strip():
+                return ""
             return f"\n<!--{content}-->\n"
 
         def convert_jira_issue(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:

--- a/confluence_markdown_exporter/utils/table_converter.py
+++ b/confluence_markdown_exporter/utils/table_converter.py
@@ -137,6 +137,8 @@ class TableConverter(MarkdownConverter):
             items = [item for item in text.splitlines() if item.strip()]
             if not items:
                 return ""
+            if len(items) == 1:
+                return items[0]
             return "- " + "<br>- ".join(items)
         return super().convert_ul(el, text, tags)
 

--- a/tests/unit/utils/test_table_converter.py
+++ b/tests/unit/utils/test_table_converter.py
@@ -131,6 +131,42 @@ class TestTableConverter:
         result = converter.convert_ul(el, "item", parent_tags=False)  # type: ignore[arg-type]
         assert "item" in result
 
+    def test_single_item_ul_in_cell_strips_list_symbol(self) -> None:
+        """Single-item ul in a table cell should not render a leading '- '."""
+        html = """
+        <table>
+            <tr>
+                <th>Header</th>
+            </tr>
+            <tr>
+                <td><ul><li>Only item</li></ul></td>
+            </tr>
+        </table>
+        """
+        converter = TableConverter()
+        result = converter.convert(html)
+
+        assert "Only item" in result
+        assert "- Only item" not in result
+
+    def test_multi_item_ul_in_cell_keeps_list_symbols(self) -> None:
+        """Multi-item ul in a table cell should still render with '- ' prefixes."""
+        html = """
+        <table>
+            <tr>
+                <th>Header</th>
+            </tr>
+            <tr>
+                <td><ul><li>First</li><li>Second</li></ul></td>
+            </tr>
+        </table>
+        """
+        converter = TableConverter()
+        result = converter.convert(html)
+
+        assert "- First" in result
+        assert "- Second" in result
+
     def test_td_detection_still_works_with_set_parent_tags(self) -> None:
         """set-based parent_tags (markdownify 1.x) must still trigger td-specific behaviour."""
         converter = TableConverter()


### PR DESCRIPTION
## Summary

Two output simplifications:
- When a hidden content renders as empty, do not print a comment
- When a bulletpoint list in a table cell only has a single item, do not include a bulletpoint.

## Test Plan

Added tests.