### PR TITLE
Support Dataview and Meta Bind for page properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,35 +14,31 @@
 
 ## Features
 
-- Converts Confluence pages to Markdown format.
-- Uses the Atlassian API to export individual pages, pages including children, and whole spaces.
-- Supports various Confluence elements such as headings, paragraphs, lists, tables, and more.
-- Retains formatting such as bold, italic, and underline.
-- Converts Confluence macros to equivalent Markdown syntax where possible.
-- Handles images and attachments by linking them appropriately in the Markdown output.
-- Supports extended Markdown features like tasks, alerts, and front matter.
-- Skips unchanged pages by default — only re-exports pages that have changed since the last run.
-- Supports Confluence add-ons: [draw.io](https://marketplace.atlassian.com/apps/1210933/draw-io-diagrams-uml-bpmn-aws-erd-flowcharts), [PlantUML](https://marketplace.atlassian.com/apps/1222993/flowchart-plantuml-diagrams-for-confluence), [Markdown Extensions](https://marketplace.atlassian.com/apps/1215703/markdown-extensions-for-confluence)
+Exports individual pages, pages with descendants, or entire spaces via the Atlassian API. Skips unchanged pages by default — only re-exports what has changed since the last run.
 
-## Supported Markdown Elements
+### Supported Confluence Features
 
-- **Headings**: Converts Confluence headings to Markdown headings.
-- **Paragraphs**: Converts Confluence paragraphs to Markdown paragraphs.
-- **Lists**: Supports both ordered and unordered lists.
-- **Tables**: Converts Confluence tables to Markdown tables.
-- **Formatting**: Supports bold, italic, and underline text.
-- **Links**: Converts Confluence links to Markdown links.
-- **Images**: Converts Confluence images to Markdown images with appropriate links.
-- **Code Blocks**: Converts Confluence code blocks to Markdown code blocks.
-- **Tasks**: Converts Confluence tasks to Markdown task lists.
-- **Alerts**: Converts Confluence info panels to Markdown alert blocks.
-- **Text Highlights**: Preserves Confluence text highlights with their original colour.
-- **Font Colors**: Preserves Confluence font colours.
-- **Status Badges**: Converts Confluence status badges to coloured highlights.
-- **Inline Comments**: Exports open inline comments as sidecar files placed next to each page.
-- **Front Matter**: Adds front matter to the Markdown files for metadata like page properties and page labels.
-- **Mermaid**: Converts Mermaid diagrams embedded in draw.io diagrams to Mermaid code blocks.
-- **PlantUML**: Converts PlantUML diagrams to Markdown code blocks.
+#### Content & formatting
+
+- **Rich text** — headings, paragraphs, bold, italic, underline, lists, tables, links, images, and attachments
+- **Code blocks** — language-aware fenced code blocks
+- **Task lists** — checkboxes with completion state
+- **Text highlights & font colours** — preserved with inline HTML colour styling
+- **Status badges** — converted to coloured inline highlights
+- **Info / note / tip / warning panels** — converted to Markdown alert blocks (`[!NOTE]`, `[!TIP]`, …)
+- **Inline comments** — open comments exported as sidecar files next to each page
+
+#### Page metadata
+
+- **Page properties** — Page Properties macro exported as YAML front matter, [Dataview](https://blacksmithgu.github.io/obsidian-dataview/) inline fields, or [Meta Bind](https://www.moritzjung.dev/obsidian-meta-bind-plugin-docs/) VIEW fields; duplicate keys are disambiguated automatically (configurable via `export.page_properties_format`)
+- **Page Properties Report** — dynamic cross-page property tables exported as a static snapshot or a live [Dataview](https://blacksmithgu.github.io/obsidian-dataview/) DQL query (configurable via `export.page_properties_report_format`)
+- **Page labels** — exported as `tags` in YAML front matter
+
+#### Diagrams & add-ons
+
+- **[draw.io](https://marketplace.atlassian.com/apps/1210933/draw-io-diagrams-uml-bpmn-aws-erd-flowcharts)** — diagram files saved as attachments; embedded Mermaid diagrams extracted as fenced Mermaid blocks
+- **[PlantUML](https://marketplace.atlassian.com/apps/1222993/flowchart-plantuml-diagrams-for-confluence)** — exported as fenced PlantUML code blocks
+- **[Markdown Extensions](https://marketplace.atlassian.com/apps/1215703/markdown-extensions-for-confluence)** — pass-through of raw Markdown macro content
 
 ## Usage
 
@@ -53,16 +49,19 @@ To use the confluence-markdown-exporter, follow these steps:
 Install or update confluence-markdown-exporter with a single command.
 
 **macOS and Linux**
+
 ```bash
 curl -LsSf uvx.sh/confluence-markdown-exporter/install.sh | sh
 ```
 
 **Windows**
+
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://uvx.sh/confluence-markdown-exporter/install.ps1 | iex"
 ```
 
 Installing a specific version
+
 ```bash
 curl -LsSf uvx.sh/confluence-markdown-exporter/4.2.1/install.sh | sh
 ```
@@ -86,6 +85,7 @@ cme page <page-url>
 ```
 
 Supported page URL formats:
+
 - Confluence Cloud: <https://company.atlassian.net/wiki/spaces/SPACEKEY/pages/123456789/Page+Title>
 - Confluence Cloud (API gateway): <https://api.atlassian.com/ex/confluence/CLOUDID/wiki/spaces/SPACEKEY/pages/123456789/Page+Title>
 - Confluence Server (long): <https://wiki.company.com/display/SPACEKEY/Page+Title>
@@ -117,6 +117,7 @@ cme space <space-url>
 ```
 
 Supported space URL formats:
+
 - Confluence Cloud: <https://company.atlassian.net/wiki/spaces/SPACEKEY>
 - Confluence Cloud (API gateway): <https://api.atlassian.com/ex/confluence/CLOUDID/wiki/spaces/SPACEKEY>
 - Confluence Server (long): <https://wiki.company.com/display/SPACEKEY>
@@ -155,15 +156,15 @@ All configuration and authentication is stored in a single JSON file managed by 
 
 ### Config Commands
 
-| Command | Description |
-| ------- | ----------- |
-| `cme config` | Open the interactive configuration menu |
-| `cme config list` | Print the full configuration as YAML |
-| `cme config get <key>` | Print the value of a single config key |
-| `cme config set <key=value>...` | Set one or more config values |
-| `cme config edit <key>` | Open the interactive editor for a specific key |
-| `cme config path` | Print the path to the config file |
-| `cme config reset` | Reset all configuration to defaults |
+| Command                         | Description                                    |
+| ------------------------------- | ---------------------------------------------- |
+| `cme config`                    | Open the interactive configuration menu        |
+| `cme config list`               | Print the full configuration as YAML           |
+| `cme config get <key>`          | Print the value of a single config key         |
+| `cme config set <key=value>...` | Set one or more config values                  |
+| `cme config edit <key>`         | Open the interactive editor for a specific key |
+| `cme config path`               | Print the path to the config file              |
+| `cme config reset`              | Reset all configuration to defaults            |
 
 #### Interactive Menu
 
@@ -239,7 +240,7 @@ Resets the entire configuration to factory defaults after confirmation.
 
 All options can be set via the config file (using `cme config set`) or overridden for the current session via environment variables. ENV vars take precedence over stored config and are **not** persisted. ENV var names use the `CME_` prefix and `__` as the nested delimiter (matching the key in uppercase).
 
-#### export.*
+#### export.\*
 
 ##### export.log_level
 
@@ -262,11 +263,11 @@ How to generate links to pages in Markdown. Options: `relative` (default), `abso
 - Default: `relative`
 - ENV Var: `CME_EXPORT__PAGE_HREF`
 
-| Value | Output |
-|-------|--------|
-| `relative` | `[Page Title](../path/to/page.md)` |
+| Value      | Output                                 |
+| ---------- | -------------------------------------- |
+| `relative` | `[Page Title](../path/to/page.md)`     |
 | `absolute` | `[Page Title](/space/path/to/page.md)` |
-| `wiki` | `[[Page Title]]` |
+| `wiki`     | `[[Page Title]]`                       |
 
 ##### export.page_path
 
@@ -282,11 +283,11 @@ How to generate links to attachments in Markdown. Options: `relative` (default),
 - Default: `relative`
 - ENV Var: `CME_EXPORT__ATTACHMENT_HREF`
 
-| Value | Output |
-|-------|--------|
-| `relative` | `[file.pdf](../path/to/file.pdf)` / `![alt](../path/to/image.png)` |
+| Value      | Output                                                                             |
+| ---------- | ---------------------------------------------------------------------------------- |
+| `relative` | `[file.pdf](../path/to/file.pdf)` / `![alt](../path/to/image.png)`                 |
 | `absolute` | `[file.pdf](/space/attachments/file.pdf)` / `![alt](/space/attachments/image.png)` |
-| `wiki` | `[[file.pdf\|File Title]]` / `![[image.png\|alt text]]` |
+| `wiki`     | `[[file.pdf\|File Title]]` / `![[image.png\|alt text]]`                            |
 
 ##### export.attachment_path
 
@@ -309,12 +310,34 @@ Whether to include breadcrumb links at the top of the page.
 - Default: `True`
 - ENV Var: `CME_EXPORT__PAGE_BREADCRUMBS`
 
-##### export.page_properties_as_front_matter
+##### export.page_properties_format
 
-Whether to convert Confluence Page Properties macro tables into YAML front matter. When enabled, key-value pairs in the macro are extracted and written as YAML front matter at the top of the exported file. When disabled, the macro is converted to a regular markdown table.
+Controls how Confluence Page Properties macros (key-value tables) are rendered. Duplicate property keys are automatically disambiguated by appending a counter (e.g. `status`, `status_2`, `status_3`).
 
-- Default: `True`
-- ENV Var: `CME_EXPORT__PAGE_PROPERTIES_AS_FRONT_MATTER`
+| Value                   | Description                                                                                                                                                                                                    |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `frontmatter`           | Extract to YAML front matter; table is removed from the page body                                                                                                                                              |
+| `table`                 | Keep as a regular markdown table; no metadata is written                                                                                                                                                       |
+| `frontmatter_and_table` | Write to YAML front matter **and** keep the original table in the body (default)                                                                                                                               |
+| `dataview-inline-field` | Replace the table with [Dataview](https://blacksmithgu.github.io/obsidian-dataview/) `Key:: Value` inline fields                                                                                               |
+| `meta-bind-view-fields` | Write YAML front matter and a table using [Meta Bind](https://www.moritzjung.dev/obsidian-meta-bind-plugin-docs/) `VIEW[{key}][text]` fields                                                                   |
+
+> **Migration:** The legacy `page_properties_as_front_matter=true/false` is still accepted and maps to `frontmatter` / `table` respectively.
+
+- Default: `frontmatter_and_table`
+- ENV Var: `CME_EXPORT__PAGE_PROPERTIES_FORMAT`
+
+##### export.page_properties_report_format
+
+Controls how Confluence Page Properties Report macros (dynamic cross-page property tables) are rendered.
+
+| Value      | Description                                                                                                                                                                                                                                                                                                |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `frozen`   | Export the rendered table as a static markdown table snapshot (default)                                                                                                                                                                                                                                    |
+| `dataview` | Translate the CQL query to an [Obsidian Dataview](https://blacksmithgu.github.io/obsidian-dataview/) DQL code block; requires the Dataview plugin and all referenced child pages to be exported with their page properties as front matter; falls back to a frozen table if the query cannot be translated |
+
+- Default: `frozen`
+- ENV Var: `CME_EXPORT__PAGE_PROPERTIES_REPORT_FORMAT`
 
 ##### export.filename_encoding
 
@@ -362,14 +385,14 @@ Fetch and export open inline comments as a sidecar `.comments.md` file placed ne
 
 Whether to convert Confluence status badge macros to HTML `<mark>` elements coloured with the badge's background colour. Each lozenge variant maps to an Atlassian design-system pastel:
 
-| Lozenge | Colour | Hex |
-| ------- | ------ | --- |
-| Gray (default) | Gray | `#dfe1e6` |
-| Blue | Blue | `#cce0ff` |
-| Green | Green | `#baf3db` |
-| Yellow | Yellow / Orange | `#f8e6a0` |
-| Red | Red | `#ffd5d2` |
-| Purple | Purple / Violet | `#dfd8fd` |
+| Lozenge        | Colour          | Hex       |
+| -------------- | --------------- | --------- |
+| Gray (default) | Gray            | `#dfe1e6` |
+| Blue           | Blue            | `#cce0ff` |
+| Green          | Green           | `#baf3db` |
+| Yellow         | Yellow / Orange | `#f8e6a0` |
+| Red            | Red             | `#ffd5d2` |
+| Purple         | Purple / Violet | `#dfd8fd` |
 
 When disabled, only the badge label text is kept.
 
@@ -418,7 +441,7 @@ Number of page IDs per batch when checking page existence during cleanup. Capped
 - Default: `250`
 - ENV Var: `CME_EXPORT__EXISTENCE_CHECK_BATCH_SIZE`
 
-#### connection_config.*
+#### connection_config.\*
 
 ##### connection_config.backoff_and_retry
 
@@ -483,7 +506,7 @@ Maximum number of parallel workers for page export. Set to `1` for serial/debug 
 - Default: `20`
 - ENV Var: `CME_CONNECTION_CONFIG__MAX_WORKERS`
 
-#### auth.*
+#### auth.\*
 
 > [!Note]
 > Auth credentials use URL-keyed nested dicts (e.g. `auth.confluence["https://company.atlassian.net"]`) and cannot be mapped to flat ENV var names. Use `cme config edit auth.confluence` or `cme config set` for auth configuration.
@@ -586,12 +609,27 @@ cme config set \
   export.include_document_title=false \
   export.page_breadcrumbs=false \
   export.page_href=wiki \
-  export.attachment_href=wiki
+  export.attachment_href=wiki \
+  export.page_properties_format=meta-bind-view-fields \
+  export.page_properties_report_format=dataview
 ```
 
 Obsidian natively renders the document title and page breadcrumbs, so both are disabled to avoid redundant output. Wiki-style links (`[[Page Title]]` and `![[attachment.png]]`) are used so Obsidian can resolve links by title across the vault without depending on the file system path.
 
+`meta-bind-view-fields` writes all page properties to YAML front matter and replaces the property table with inline `` `VIEW[{key}][text]` `` fields. `dataview` replaces frozen Page Properties Report snapshots with live Dataview DQL queries that re-evaluate across your vault.
+
+The following Obsidian plugins are recommended for the best experience:
+
+| Plugin | Purpose |
+| ------ | ------- |
+| [Dataview](https://blacksmithgu.github.io/obsidian-dataview/) | Query and display page metadata across the vault; powers the Page Properties Report DQL queries |
+| [Meta Bind](https://www.moritzjung.dev/obsidian-meta-bind-plugin-docs/) | Renders the exported `VIEW[{key}][text]` fields as live, readable values inline in the page body; works alongside Dataview |
+| [Highlightr](https://github.com/chetachiezikeuzor/Highlightr-Plugin) | Renders the colour highlights exported from Confluence text highlights |
+| [Folder Notes](https://github.com/LostPaul/obsidian-folder-notes) | Opens the page note when clicking a folder, mirroring Confluence's page-as-folder structure |
+
 > **Note:** Wiki links resolve by page title. If multiple pages share the same title across spaces, Obsidian may link to the wrong file. In that case, omit `export.page_href=wiki` and use `relative` or `absolute` links instead.
+>
+> **Note:** Dataview report queries only work correctly if all referenced child pages are also exported and their page properties are available as front matter.
 
 #### Azure DevOps (ADO) Wikis
 
@@ -621,9 +659,9 @@ The exporter automatically detects CI environments and suppresses rich terminal 
 
 Detection is based on two standard environment variables:
 
-| Variable | Effect |
-| -------- | ------ |
-| `CI=true` | Disables ANSI color codes and live terminal output |
+| Variable     | Effect                                                                    |
+| ------------ | ------------------------------------------------------------------------- |
+| `CI=true`    | Disables ANSI color codes and live terminal output                        |
 | `NO_COLOR=1` | Same effect (follows the [no-color.org](https://no-color.org) convention) |
 
 Most CI platforms (GitHub Actions, GitLab CI, CircleCI, Jenkins, etc.) set `CI=true` automatically.
@@ -642,7 +680,6 @@ CME_EXPORT__LOG_LEVEL=WARNING cme pages <page-url>
 ```
 
 This is useful for using different log levels for different environments or for scripting.
-
 
 ## Compatibility
 

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1306,7 +1306,9 @@ class Page(Document):
         def convert_page_properties(
             self, el: BeautifulSoup, text: str, parent_tags: list[str]
         ) -> str | None:
-            if not settings.export.page_properties_as_front_matter:
+            fmt = settings.export.page_properties_format
+
+            if fmt == "table":
                 return text
 
             rows = [
@@ -1317,14 +1319,34 @@ class Page(Document):
             if not rows:
                 return None
 
-            props = {
-                row[0].get_text(strip=True): self.convert(str(row[1])).strip()
-                for row in rows
-                if len(row) == 2  # noqa: PLR2004
-            }
+            props: dict[str, str] = {}
+            key_counts: dict[str, int] = {}
+            for row in rows:
+                if len(row) == 2:  # noqa: PLR2004
+                    raw_key = row[0].get_text(strip=True)
+                    count = key_counts.get(raw_key, 0) + 1
+                    key_counts[raw_key] = count
+                    unique_key = raw_key if count == 1 else f"{raw_key} {count}"
+                    props[unique_key] = self.convert(str(row[1])).strip()
 
-            self.set_page_properties(**props)
-            return None
+            if fmt in ("frontmatter", "frontmatter_and_table", "meta-bind-view-fields"):
+                self.set_page_properties(**props)
+
+            if fmt == "frontmatter":
+                return None
+
+            if fmt == "frontmatter_and_table":
+                return text
+
+            if fmt == "dataview-inline-field":
+                lines = "\n".join(f"{k}:: {v}" for k, v in props.items())
+                return f"\n{lines}\n"
+
+            # meta-bind-view-fields: two-column table with VIEW fields in value column
+            rows = "\n".join(
+                f"| {k} | `VIEW[{{{sanitize_key(k)}}}][text]` |" for k in props
+            )
+            return f"\n| Property | Value |\n| -------- | ----- |\n{rows}\n"
 
         def convert_alert(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
             """Convert Confluence info macros to Markdown GitHub style alerts.
@@ -2154,11 +2176,65 @@ class Page(Document):
             data_cql = el.get("data-cql")
             if not data_cql:
                 return ""
+
+            if settings.export.page_properties_report_format == "dataview":
+                dql = self._cql_to_dataview(el, str(data_cql))
+                if dql is not None:
+                    return f"\n```dataview\n{dql}\n```\n"
+
             soup = BeautifulSoup(self.page.body_export, "html.parser")
             table = soup.find("table", {"data-cql": data_cql})
             if not table:
                 return ""
             return super().convert_table(table, "", parent_tags)  # type: ignore -
+
+        def _cql_to_dataview(self, el: BeautifulSoup, cql: str) -> str | None:
+            """Translate a Confluence CQL query to an Obsidian Dataview DQL query.
+
+            Returns None if the CQL cannot be meaningfully translated.
+            """
+            current_content_id = str(el.get("data-current-content-id", ""))
+            headings_raw = str(el.get("data-headings", ""))
+            first_col = str(el.get("data-first-column-heading", "Title"))
+            sort_by = str(el.get("data-sort-by", first_col))
+            reverse_sort = str(el.get("data-reverse-sort", "false")).lower() == "true"
+
+            label_conditions = [
+                m.group(1)
+                for m in re.finditer(r'label\s*=\s*"([^"]+)"', cql, re.IGNORECASE)
+            ]
+
+            parent_match = re.search(r'parent\s*=\s*"?(\d+)"?', cql, re.IGNORECASE)
+
+            from_clause: str | None = None
+            if parent_match and parent_match.group(1) == current_content_id:
+                folder = str(self.page.export_path.parent).replace("\\", "/")
+                from_clause = f'FROM "{folder}"'
+
+            if from_clause is None and not label_conditions:
+                return None
+
+            lines: list[str] = []
+
+            if headings_raw:
+                headings = [h.strip() for h in headings_raw.split(",") if h.strip()]
+                col_names = ", ".join(sanitize_key(h) for h in headings)
+                lines.append(f"TABLE {col_names}")
+            else:
+                lines.append("TABLE")
+
+            if from_clause:
+                lines.append(from_clause)
+
+            if label_conditions:
+                where_parts = [f'contains(tags, "#{lbl}")' for lbl in label_conditions]
+                lines.append(f"WHERE {' AND '.join(where_parts)}")
+
+            sort_col = sanitize_key(sort_by)
+            sort_dir = "DESC" if reverse_sort else "ASC"
+            lines.append(f"SORT {sort_col} {sort_dir}")
+
+            return "\n".join(lines)
 
         def _get_path_for_href(
             self, path: Path, style: Literal["absolute", "relative", "wiki"]

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -413,17 +413,50 @@ class ExportConfig(BaseModel):
         title="Page Breadcrumbs",
         description="Whether to include breadcrumb links at the top of the page.",
     )
-    page_properties_as_front_matter: bool = Field(
-        default=True,
-        title="Page Properties as Front Matter",
+    page_properties_format: Literal[
+        "frontmatter",
+        "table",
+        "frontmatter_and_table",
+        "dataview-inline-field",
+        "meta-bind-view-fields",
+    ] = Field(
+        default="frontmatter_and_table",
+        title="Page Properties Format",
         description=(
-            "Whether to convert Confluence page property tables (Page Properties macro) "
-            "into YAML front matter. "
-            "When enabled (default), the macro's key-value table is extracted and written "
-            "as YAML front matter at the top of the exported file. "
-            "When disabled, the macro is converted to a regular markdown table."
+            "How to render Confluence Page Properties macros (Page Properties macro).\n"
+            "  frontmatter: extract to YAML front matter only (table removed from content)\n"
+            "  table: keep as markdown table only (no metadata)\n"
+            "  frontmatter_and_table: front matter + keep original table in content (default)\n"
+            "  dataview-inline-field: replace table with Dataview Key:: Value inline fields\n"
+            "  meta-bind-view-fields: front matter + Meta Bind VIEW fields inline (requires plugin)"
         ),
     )
+    page_properties_report_format: Literal["frozen", "dataview"] = Field(
+        default="frozen",
+        title="Page Properties Report Format",
+        description=(
+            "How to render Confluence Page Properties Report macros.\n"
+            "  frozen: export the rendered table as a static markdown table (default)\n"
+            "  dataview: translate the CQL query to an Obsidian Dataview DQL code block;\n"
+            "    requires the Dataview plugin and all referenced child pages to be exported\n"
+            "    with their page properties as frontmatter; falls back to frozen on failure"
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_page_properties(cls, data: object) -> object:
+        """Migrate legacy page_properties_as_front_matter bool to page_properties_format."""
+        if not isinstance(data, dict):
+            return data
+        old_val = data.pop("page_properties_as_front_matter", None)
+        if old_val is not None and "page_properties_format" not in data:
+            if str(old_val).lower() in ("false", "0"):
+                data["page_properties_format"] = "table"
+            else:
+                data["page_properties_format"] = "frontmatter"
+        return data
+
     filename_encoding: str = Field(
         default='"<":"_",">":"_",":":"_","\\"":"_","/":"_","\\\\":"_","|":"_","?":"_","*":"_","\\u0000":"_","[":"_","]":"_","\'":"_","’":"_","´":"_","`":"_"',  # noqa: RUF001
         title="Filename Encoding",

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -422,3 +422,212 @@ class TestStatusBadgeConversion:
             result = converter.convert(html).strip()
         assert "<mark" not in result
         assert "BLOCKED" in result
+
+
+_DETAILS_HTML = """
+<div data-macro-name="details">
+    <table>
+        <tr><th>Author</th><td>John Doe</td></tr>
+        <tr><th>Status</th><td>Active</td></tr>
+    </table>
+</div>
+"""
+
+
+class TestPagePropertiesFormat:
+    """Page Properties macro renders according to page_properties_format setting."""
+
+    def _converter(self) -> Page.Converter:
+        return Page.Converter(MockPage())
+
+    def test_frontmatter_removes_table(self) -> None:
+        converter = self._converter()
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_format = "frontmatter"
+            result = converter.convert(_DETAILS_HTML)
+        assert "Author" not in result
+        assert "author" in converter.page_properties
+        assert converter.page_properties["author"] == "John Doe"
+
+    def test_table_keeps_table_no_properties(self) -> None:
+        converter = self._converter()
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_format = "table"
+            result = converter.convert(_DETAILS_HTML)
+        assert "Author" in result
+        assert converter.page_properties == {}
+
+    def test_frontmatter_and_table_keeps_both(self) -> None:
+        converter = self._converter()
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_format = "frontmatter_and_table"
+            result = converter.convert(_DETAILS_HTML)
+        assert "Author" in result
+        assert "author" in converter.page_properties
+        assert converter.page_properties["author"] == "John Doe"
+
+    def test_dataview_inline_field(self) -> None:
+        converter = self._converter()
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_format = "dataview-inline-field"
+            result = converter.convert(_DETAILS_HTML)
+        assert "Author:: John Doe" in result
+        assert "Status:: Active" in result
+        assert "|" not in result
+        assert converter.page_properties == {}
+
+    def test_meta_bind_view_fields(self) -> None:
+        converter = self._converter()
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_format = "meta-bind-view-fields"
+            result = converter.convert(_DETAILS_HTML)
+        assert "| Author | `VIEW[{author}][text]` |" in result
+        assert "| Status | `VIEW[{status}][text]` |" in result
+        assert "author" in converter.page_properties
+        assert "status" in converter.page_properties
+
+    def test_duplicate_keys_get_numeric_suffix(self) -> None:
+        html = """
+        <div data-macro-name="details">
+            <table>
+                <tr><th>Status</th><td>Draft</td></tr>
+                <tr><th>Status</th><td>Review</td></tr>
+                <tr><th>Status</th><td>Final</td></tr>
+            </table>
+        </div>
+        """
+        converter = self._converter()
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_format = "frontmatter"
+            converter.convert(html)
+        assert converter.page_properties["status"] == "Draft"
+        assert converter.page_properties["status_2"] == "Review"
+        assert converter.page_properties["status_3"] == "Final"
+
+    def test_duplicate_keys_in_inline_fields(self) -> None:
+        html = """
+        <div data-macro-name="details">
+            <table>
+                <tr><th>Tag</th><td>foo</td></tr>
+                <tr><th>Tag</th><td>bar</td></tr>
+            </table>
+        </div>
+        """
+        converter = self._converter()
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_format = "dataview-inline-field"
+            result = converter.convert(html)
+        assert "Tag:: foo" in result
+        assert "Tag 2:: bar" in result
+
+
+class TestPagePropertiesMigration:
+    """Legacy page_properties_as_front_matter bool migrates to page_properties_format."""
+
+    def test_old_true_maps_to_frontmatter(self) -> None:
+        from confluence_markdown_exporter.utils.app_data_store import ExportConfig
+
+        config = ExportConfig.model_validate({"page_properties_as_front_matter": True})
+        assert config.page_properties_format == "frontmatter"
+
+    def test_old_false_maps_to_table(self) -> None:
+        from confluence_markdown_exporter.utils.app_data_store import ExportConfig
+
+        config = ExportConfig.model_validate({"page_properties_as_front_matter": False})
+        assert config.page_properties_format == "table"
+
+    def test_new_field_takes_precedence_over_old(self) -> None:
+        from confluence_markdown_exporter.utils.app_data_store import ExportConfig
+
+        config = ExportConfig.model_validate(
+            {"page_properties_as_front_matter": True, "page_properties_format": "table"}
+        )
+        assert config.page_properties_format == "table"
+
+    def test_default_is_frontmatter_and_table(self) -> None:
+        from confluence_markdown_exporter.utils.app_data_store import ExportConfig
+
+        config = ExportConfig()
+        assert config.page_properties_format == "frontmatter_and_table"
+
+
+class TestPagePropertiesReportDataview:
+    """Page Properties Report macro can be exported as a Dataview DQL query."""
+
+    _REPORT_HTML = (
+        '<table class="aui metadata-summary-macro null"'
+        ' data-cql=\'label = "tool-validation" and parent = "42"\''
+        ' data-current-content-id="42"'
+        ' data-current-space-key="TS"'
+        ' data-first-column-heading="Title"'
+        ' data-headings="Tool Version,Approved for Use"'
+        ' data-sort-by="Title"'
+        ' data-reverse-sort="false">'
+        "</table>"
+    )
+
+    _BODY_EXPORT = (
+        '<table class="aui metadata-summary-macro null"'
+        ' data-cql=\'label = "tool-validation" and parent = "42"\''
+        ">"
+        "<tr><th>Title</th><th>Tool Version</th><th>Approved for Use</th></tr>"
+        "<tr><td>Page A</td><td>1.0</td><td>Yes</td></tr>"
+        "</table>"
+    )
+
+    class _MockPageWithExport:
+        def __init__(self, body_export: str = "") -> None:
+            from pathlib import Path
+
+            self.id = 42
+            self.title = "Test Page"
+            self.html = ""
+            self.labels: list = []
+            self.ancestors: list = []
+            self.body_export = body_export
+            self.export_path = Path("Test Space/Test Page/Test Page.md")
+
+        def get_attachment_by_file_id(self, file_id: str) -> None:
+            return None
+
+    def test_dataview_output_contains_table_clause(self) -> None:
+        page = self._MockPageWithExport(body_export=self._BODY_EXPORT)
+        converter = Page.Converter(page)
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_report_format = "dataview"
+            result = converter.convert(self._REPORT_HTML)
+        assert "```dataview" in result
+        assert "TABLE tool_version, approved_for_use" in result
+
+    def test_dataview_output_contains_from_clause(self) -> None:
+        page = self._MockPageWithExport(body_export=self._BODY_EXPORT)
+        converter = Page.Converter(page)
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_report_format = "dataview"
+            result = converter.convert(self._REPORT_HTML)
+        assert 'FROM "Test Space/Test Page"' in result
+
+    def test_dataview_output_contains_where_clause(self) -> None:
+        page = self._MockPageWithExport(body_export=self._BODY_EXPORT)
+        converter = Page.Converter(page)
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_report_format = "dataview"
+            result = converter.convert(self._REPORT_HTML)
+        assert 'contains(tags, "#tool-validation")' in result
+
+    def test_dataview_output_contains_sort_clause(self) -> None:
+        page = self._MockPageWithExport(body_export=self._BODY_EXPORT)
+        converter = Page.Converter(page)
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_report_format = "dataview"
+            result = converter.convert(self._REPORT_HTML)
+        assert "SORT title ASC" in result
+
+    def test_frozen_table_when_format_is_frozen(self) -> None:
+        page = self._MockPageWithExport(body_export=self._BODY_EXPORT)
+        converter = Page.Converter(page)
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_report_format = "frozen"
+            result = converter.convert(self._REPORT_HTML)
+        assert "```dataview" not in result
+        assert "Page A" in result


### PR DESCRIPTION
## Summary

Currently we can only choose between ignoring page properties all together and exporting a frozen capture of the Confluence pages or change the page content by moving the content to the front matter. Especially in obsidian there are much more advanced options to maintain these dynamic page properties and reports via the Dataview and Meta Bind plugins. Add support for these.

## Test Plan

Tests added.
