### PR TITLE
Add option to disable attachment download

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,13 @@ Export all attachments, not only those referenced by a page. Note: exporting lar
 - Default: `False`
 - ENV Var: `CME_EXPORT__ATTACHMENT_EXPORT_ALL`
 
+##### export.attachments_export
+
+Whether to download attachment files to disk. When disabled, no attachment files are written and no lockfile entries are created — useful when you only want the Markdown text and want to save disk space and bandwidth. Attachment metadata is still fetched from the Confluence API so image and file links in the page body continue to resolve in the rendered Markdown, but the referenced files will not exist locally.
+
+- Default: `True`
+- ENV Var: `CME_EXPORT__ATTACHMENTS_EXPORT`
+
 ##### export.image_captions
 
 Whether to export Confluence image captions in the exported Markdown. When enabled, the storage format of each page is fetched (via an additional API body expansion) and `ac:image` captions are extracted and rendered as an italic line directly below the image:

--- a/confluence_markdown_exporter/config.py
+++ b/confluence_markdown_exporter/config.py
@@ -40,6 +40,7 @@ _CONFIG_KEYS_EPILOG = (
     "| `export.convert_status_badges` | Convert Confluence status badges to `<mark>` elements |\n\n"
     "| `export.convert_text_highlights` | Convert background-color spans to `<mark>` elements |\n\n"
     "| `export.convert_font_colors` | Convert font-color spans to `<font>` elements |\n\n"
+    "| `export.attachments_export` | Download attachment files to disk (default: `true`) |\n\n"
     "| `export.filename_length` | Maximum filename length (default: 255) |\n\n"
     "| `connection_config.max_workers` | Parallel export workers (default: 20) |\n\n"
     "| `connection_config.use_v2_api` | Use Confluence REST API v2 (`true`/`false`) |\n\n"

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1076,6 +1076,9 @@ class Page(Document):
         ]
 
     def export_attachments(self) -> dict[str, AttachmentEntry]:
+        if not settings.export.attachments_export:
+            logger.debug("Attachment download disabled for page id=%s", self.id)
+            return {}
         old_entries = LockfileManager.get_page_attachment_entries(str(self.id))
         new_entries: dict[str, AttachmentEntry] = {}
         output_path = settings.export.output_path

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -408,6 +408,18 @@ class ExportConfig(BaseModel):
             "\nNote: large and multiple attachments will take more time"
         ),
     )
+    attachments_export: bool = Field(
+        default=True,
+        title="Attachments Export",
+        description=(
+            "Whether to download attachment files to disk. "
+            "When disabled, no attachment files are written and no lockfile "
+            "entries are created. Attachment metadata is still fetched from "
+            "the Confluence API so image and file links in the page body "
+            "continue to resolve, but the referenced files will not exist "
+            "locally."
+        ),
+    )
     image_captions: bool = Field(
         default=False,
         title="Image Captions",

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
@@ -798,3 +800,122 @@ class TestPagePropertiesReportDataview:
             result = converter.convert(self._REPORT_HTML)
         assert "```dataview" not in result
         assert "Page A" in result
+
+
+class TestAttachmentsExportFlag:
+    """Tests for the export.attachments_export setting."""
+
+    def _make_attachment_mock(self, att_id: str = "att-1", version: int = 3) -> MagicMock:
+        att = MagicMock()
+        att.id = att_id
+        att.version.number = version
+        att.export_path = Path(f"attachments/{att_id}.bin")
+        return att
+
+    def _make_page_mock(self, attachments: list) -> MagicMock:
+        page = MagicMock()
+        page.id = 42
+        page._attachments_for_export.return_value = attachments
+        return page
+
+    def test_default_true_exports_attachments(self, tmp_path: Path) -> None:
+        """With attachments_export=True (default), attachments are downloaded."""
+        att = self._make_attachment_mock()
+        page = self._make_page_mock([att])
+
+        with (
+            patch("confluence_markdown_exporter.confluence.settings") as mock_settings,
+            patch(
+                "confluence_markdown_exporter.confluence.LockfileManager"
+            ) as mock_lockfile,
+            patch("confluence_markdown_exporter.confluence.get_stats"),
+        ):
+            mock_settings.export.attachments_export = True
+            mock_settings.export.output_path = tmp_path
+            mock_lockfile.get_page_attachment_entries.return_value = {}
+
+            result = Page.export_attachments(page)
+
+        att.export.assert_called_once()
+        assert "att-1" in result
+
+    def test_disabled_skips_download_and_lockfile(self) -> None:
+        """With attachments_export=False, no download and no lockfile lookup."""
+        att = self._make_attachment_mock()
+        page = self._make_page_mock([att])
+
+        with (
+            patch("confluence_markdown_exporter.confluence.settings") as mock_settings,
+            patch(
+                "confluence_markdown_exporter.confluence.LockfileManager"
+            ) as mock_lockfile,
+            patch("confluence_markdown_exporter.confluence.get_stats"),
+        ):
+            mock_settings.export.attachments_export = False
+
+            result = Page.export_attachments(page)
+
+        assert result == {}
+        att.export.assert_not_called()
+        mock_lockfile.get_page_attachment_entries.assert_not_called()
+
+    def test_metadata_still_populated_when_disabled(self) -> None:
+        """Page.from_json populates Page.attachments even when downloads are disabled.
+
+        Guards against future scope creep that would gate metadata loading on
+        the same flag — body image and file links must keep resolving.
+        """
+        base_url = "https://example.atlassian.net"
+        fake_space = Space(
+            base_url=base_url, key="K", name="Space", description="", homepage=None
+        )
+        fake_user = User(
+            account_id="", username="", display_name="", public_name="", email=""
+        )
+        fake_version = Version(number=1, by=fake_user, when="", friendly_when="")
+        fake_attachment = Attachment(
+            base_url=base_url,
+            id="att-1",
+            title="file.png",
+            space=fake_space,
+            ancestors=[],
+            version=fake_version,
+            file_size=10,
+            media_type="image/png",
+            media_type_description="",
+            file_id="file-id-1",
+            collection_name="",
+            download_link="",
+            comment="",
+        )
+        page_data = {
+            "id": 42,
+            "title": "Test",
+            "_expandable": {"space": "/rest/api/space/K"},
+            "body": {
+                "view": {"value": ""},
+                "export_view": {"value": ""},
+                "editor2": {"value": ""},
+            },
+            "metadata": {"labels": {"results": []}},
+            "ancestors": [],
+            "version": {},
+        }
+
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.Attachment.from_page_id",
+                return_value=[fake_attachment],
+            ),
+            patch(
+                "confluence_markdown_exporter.confluence.Space.from_key",
+                return_value=fake_space,
+            ),
+            patch("confluence_markdown_exporter.confluence.settings") as mock_settings,
+        ):
+            mock_settings.export.attachments_export = False
+
+            page = Page.from_json(page_data, base_url)
+
+        assert len(page.attachments) == 1
+        assert page.attachments[0].id == "att-1"


### PR DESCRIPTION
# PR: Add option to disable attachment download

## Title

```
Add option to disable attachment download
```

## Body

## Summary

Adds a new boolean setting `export.attachments_export` (default `True`, no
change in default behaviour). When set to `False`, `Page.export_attachments()`
returns immediately — no files are downloaded, no lockfile entries written, no
lockfile lookup performed.

**Why:** today the exporter always downloads attachments. For users who only
want the Markdown text (wiki-to-static-site pipelines, search/RAG ingestion,
quick text-only spot-exports of large spaces) this is wasted bandwidth, disk,
and — on big spaces — the dominant slice of total export time. The closest
existing setting, `export.attachment_export_all`, only changes *scope* (all
vs. referenced) and cannot turn the download off.

**What is intentionally not changed:**

- Attachment **metadata** is still fetched in `Page.from_json` via
  `Attachment.from_page_id`. This is a cheap REST GET and keeps
  `Page.get_attachment_by_file_id` working, so image `src`s and file links in
  the Markdown body still resolve to the configured `attachment_path`. The
  files just won't exist locally.
- The `convert_attachments` macro still renders its Markdown table of links.
- `attachment_export_all` semantics, `Page.from_json`,
  `Page._attachments_for_export`, the body converters, and `Attachment.export`
  are untouched.

The flag is forward-only and does not retroactively delete previously
downloaded attachments.

The early-return is positioned **before** the lockfile lookup so disabled
pages produce zero stats noise and zero unnecessary I/O.

Both the README entry and the Pydantic field's `description=` text spell out
the trade-off (saves disk + bandwidth, but body links still point at
`attachment_path` even though the files don't exist locally). A new row is
added to the `_CONFIG_KEYS_EPILOG` table in `cme config` help output.

> Implementation written by Claude Opus 4.7 from a hand-written plan; reviewed
> and tested manually before opening this PR.

## Test Plan

Three new tests in `tests/unit/test_confluence.py` (class
`TestAttachmentsExportFlag`):

1. **Default (`True`) preserves behaviour:** `attachment.export()` is called
   and the returned dict contains the attachment entry.
2. **Disabled (`False`) skips download and lockfile lookup:**
   `attachment.export()` is **not** called, the returned dict is `{}`, and
   `LockfileManager.get_page_attachment_entries` is **not** called either —
   verifying the early-return is positioned before the lockfile read.
3. **Metadata still populated when disabled:** `Page.from_json` builds a Page
   with `len(page.attachments) == 1` even when `attachments_export=False`.
   Guards against future scope creep that would gate metadata loading on the
   same flag.

Automated:

```bash
uv run ruff check .            # clean
uv run pytest tests/unit/ -q   # 252 passed
```

**Manually tested** against a live Confluence page that has at least one
attachment:

```bash
# Default — attachment files appear under output_path/.../attachments/
CME_EXPORT__OUTPUT_PATH=/tmp/cme-attach-on \
  uv run cme pages <url-with-attachment>
# Result: attachment files present, Markdown body links to them.

# Disabled — no attachment files are written
CME_EXPORT__OUTPUT_PATH=/tmp/cme-attach-off \
  CME_EXPORT__ATTACHMENTS_EXPORT=false \
  uv run cme pages <url-with-attachment>
# Result: no attachments/ directory created; Markdown body unchanged
# (image and file links still point at the configured attachment_path).
```
