### PR TITLE
Fall back to content id when attachment fileId is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ Path template for attachments.
 - Default: `{space_name}/attachments/{attachment_file_id}{attachment_extension}`
 - ENV Var: `CME_EXPORT__ATTACHMENT_PATH`
 
+On Confluence Data Center / Server, where the API does not provide `fileId`, `{attachment_file_id}` falls back to the content id, so the default template still produces unique filenames.
+
 ##### export.attachment_export_all
 
 Export all attachments, not only those referenced by a page. Note: exporting large or many attachments increases export time.

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -638,8 +638,11 @@ class Attachment(Document):
             **super()._template_vars,
             "attachment_id": str(self.id),
             "attachment_title": sanitize_filename(title_without_ext),
-            # file_id is a GUID and does not need sanitized.
-            "attachment_file_id": self.file_id,
+            # file_id is a GUID and does not need sanitization. On
+            # Confluence Data Center / Server the API does not populate
+            # fileId, so fall back to the content id which is always
+            # present and unique.
+            "attachment_file_id": self.file_id or str(self.id),
             "attachment_extension": self.extension,
         }
 

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -375,7 +375,9 @@ class ExportConfig(BaseModel):
             "  - {ancestor_titles}: A slash-separated list of ancestor page titles.\n"
             "  - {attachment_id}: The unique ID of the attachment.\n"
             "  - {attachment_title}: The title of the attachment (without file extension).\n"
-            "  - {attachment_file_id}: The file ID of the attachment.\n"
+            "  - {attachment_file_id}: The file ID of the attachment. Falls back to "
+            "{attachment_id} on Confluence Data Center / Server, where the API does "
+            "not provide a file ID.\n"
             "  - {attachment_extension}: The file extension of the attachment,\n"
             "including the leading dot."
         ),

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -798,3 +798,31 @@ class TestPagePropertiesReportDataview:
             result = converter.convert(self._REPORT_HTML)
         assert "```dataview" not in result
         assert "Page A" in result
+
+
+class TestAttachmentTemplateVars:
+    """`attachment_file_id` falls back to the content id when fileId is empty."""
+
+    def test_cloud_style_keeps_file_id(self) -> None:
+        """Cloud attachments expose the GUID fileId verbatim."""
+        attachment = _make_attachment("content-456", "cloud-guid-123")
+        assert attachment._template_vars["attachment_file_id"] == "cloud-guid-123"
+
+    def test_dc_style_falls_back_to_content_id(self) -> None:
+        """Data Center / Server attachments fall back to the content id."""
+        attachment = _make_attachment("content-456", "")
+        assert attachment._template_vars["attachment_file_id"] == "content-456"
+
+    def test_two_dc_attachments_get_distinct_paths(self) -> None:
+        """Two DC attachments with the same extension must not collide."""
+        att1 = _make_attachment("123", "")
+        att2 = _make_attachment("124", "")
+
+        with patch("confluence_markdown_exporter.confluence.settings") as mock_settings:
+            mock_settings.export.attachment_path = (
+                "{space_name}/attachments/{attachment_file_id}{attachment_extension}"
+            )
+            path1 = att1.export_path
+            path2 = att2.export_path
+
+        assert path1 != path2


### PR DESCRIPTION
# PR: Fall back to content id when attachment fileId is empty

## Title

```
Fall back to content id when attachment fileId is empty
```

## Body

## Summary

Fixes a long-standing issue where attachments collide on Confluence Data
Center / Server installations.

**The problem.** The default `export.attachment_path` template is
`{space_name}/attachments/{attachment_file_id}{attachment_extension}`. The
`{attachment_file_id}` placeholder is filled from `Attachment.file_id`, which
in turn comes from `extensions.fileId` in the Confluence REST response.
`extensions.fileId` is a Confluence-Cloud-specific GUID. **On Confluence Data
Center / Server, the API does not include this field**, so `file_id` becomes
an empty string for every attachment, every exported file collapses to a path
of the form `…/attachments/.<ext>`, and all attachments with the same
extension overwrite each other:

```
$ ls -la output/SOMESPACE/attachments/
-rw-rw-r-- 1 user user   266293 .docx
-rw-rw-r-- 1 user user    12138 .drawio
-rw-rw-r-- 1 user user 25203810 .m4a
-rw-rw-r-- 1 user user 35849567 .mp4
-rw-rw-r-- 1 user user 15850924 .pdf
…
```

DC/Server users currently have to manually override `attachment_path` to use
`{attachment_id}` to work around this. Cloud users are unaffected.

**The fix.** In `Attachment._template_vars`, fall back `attachment_file_id`
to the content id (`str(self.id)`, always populated on every Confluence
flavour) when `file_id` is empty:

```python
"attachment_file_id": self.file_id or str(self.id),
```

- Surgical change: only the template-variable derivation. The
  `Attachment.file_id` model field still represents what the API actually
  returned (empty string on DC), so anyone reading `file_id` directly sees no
  change.
- The default `attachment_path` template is **not** changed. With this fix,
  the existing default produces unique filenames on both Cloud and DC.
- No new setting, no migration required.

Both the README entry for `export.attachment_path` and the Pydantic field's
`description=` text now mention the DC/Server fallback.

**Out of scope:** migrating existing DC users' overridden `attachment_path`
configs (they keep working as-is); changing the default `attachment_path`
template (more controversial, separate change); sourcing a "real" file ID for
DC from somewhere else (e.g., from the download URL — the content id is
plenty unique).

> Implementation written by Claude Opus 4.7 from a hand-written plan; reviewed
> and tested manually before opening this PR.

## Test Plan

Three new tests in `tests/unit/test_confluence.py`:

1. **Cloud-style attachment (fileId present):** existing behaviour preserved
   — `attachment_file_id` is the GUID.
2. **DC-style attachment (fileId empty):** fallback kicks in —
   `attachment_file_id` is the content id.
3. **Two DC attachments with the same extension:** their `export_path` values
   are different (no collision).

Automated:

```bash
uv run ruff check .            # clean
uv run pytest tests/unit/ -q   # 252 passed
```

**Manually tested** against a live Confluence Data Center instance with a
page that has multiple attachments of the same type. Before the fix, only one
file remained on disk; after the fix, every attachment is written to a
distinct path under `attachments/`.
