### PR TITLE
Avoid escaping bare URLs

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -300,6 +300,11 @@ _HTML_ELEMENTS = frozenset(
 _ANGLE_BRACKET_RE = re.compile(r"<([^<>\n]*)>")
 _CODE_FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
 _INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+_AUTOLINK_URI_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]{1,31}:[^\s<>]*$")
+_AUTOLINK_EMAIL_RE = re.compile(
+    r"^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~\-]+@[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?"
+    r"(?:\.[A-Za-z0-9](?:[A-Za-z0-9\-]{0,61}[A-Za-z0-9])?)*$"
+)
 
 
 def _extract_jira_base_url(url: str) -> str | None:
@@ -1944,6 +1949,8 @@ class Page(Document):
 
             def _escape_if_placeholder(m: re.Match) -> str:
                 inner = m.group(1)
+                if _AUTOLINK_URI_RE.match(inner) or _AUTOLINK_EMAIL_RE.match(inner):
+                    return m.group(0)
                 # Strip leading slash (closing tag), get first token, strip trailing slash
                 stripped = inner.strip().lstrip("/")
                 tag_name = re.split(r"[\s/]", stripped)[0].lower() if stripped else ""

--- a/tests/unit/test_template_placeholders.py
+++ b/tests/unit/test_template_placeholders.py
@@ -95,3 +95,26 @@ class TestTemplatePlaceholderEscaping:
         assert "\\<TOPIC\\>" in lines[0]
         assert "<TOPIC>" in lines[2]
         assert "\\<medical device\\>" in lines[4]
+
+    def test_https_autolink_preserved(self, converter: Page.Converter) -> None:
+        result = converter._escape_template_placeholders(
+            "URL: <https://api.airamed.de/v1/udi>."
+        )
+        assert result == "URL: <https://api.airamed.de/v1/udi>."
+
+    def test_http_autolink_preserved(self, converter: Page.Converter) -> None:
+        result = converter._escape_template_placeholders("see <http://example.com/path?q=1>")
+        assert result == "see <http://example.com/path?q=1>"
+
+    def test_mailto_autolink_preserved(self, converter: Page.Converter) -> None:
+        result = converter._escape_template_placeholders("contact <mailto:foo@bar.com>")
+        assert result == "contact <mailto:foo@bar.com>"
+
+    def test_email_autolink_preserved(self, converter: Page.Converter) -> None:
+        result = converter._escape_template_placeholders("contact <foo@bar.com> now")
+        assert result == "contact <foo@bar.com> now"
+
+    def test_autolink_with_space_still_escaped(self, converter: Page.Converter) -> None:
+        # Not a valid autolink (contains whitespace) — treat as placeholder
+        result = converter._escape_template_placeholders("<https://x y>")
+        assert result == "\\<https://x y\\>"


### PR DESCRIPTION
## Summary

Avoid escaping urls with `<URL/>` to `\<URL/\>`

## Test Plan

Tests updated