### PR TITLE
Add Confluence page URL to YAML front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,22 @@ Controls how Confluence Page Properties Report macros (dynamic cross-page proper
 - Default: `frozen`
 - ENV Var: `CME_EXPORT__PAGE_PROPERTIES_REPORT_FORMAT`
 
+##### export.confluence_url_in_frontmatter
+
+Whether to include the original Confluence page URL in the YAML front matter of the exported file.
+
+| Value    | Description                                                                                                |
+| -------- | ---------------------------------------------------------------------------------------------------------- |
+| `none`   | Do not include any URL (default)                                                                           |
+| `webui`  | Include `confluence_webui_url` (human-readable URL; may change when the page is renamed or moved)          |
+| `tinyui` | Include `confluence_tinyui_url` (stable short permalink based on the page ID; survives renames and moves)  |
+| `both`   | Include both fields                                                                                        |
+
+If a Page Properties macro on the page already defines `confluence_webui_url` or `confluence_tinyui_url`, the value from the macro takes precedence over the URL extracted from the API.
+
+- Default: `none`
+- ENV Var: `CME_EXPORT__CONFLUENCE_URL_IN_FRONTMATTER`
+
 ##### export.filename_encoding
 
 Character mapping for filename encoding.

--- a/confluence_markdown_exporter/config.py
+++ b/confluence_markdown_exporter/config.py
@@ -33,6 +33,8 @@ _CONFIG_KEYS_EPILOG = (
     "| `export.include_document_title` | Prepend H1 title to each page |\n\n"
     "| `export.include_toc` | Export Table of Contents macro (`true`/`false`) |\n\n"
     "| `export.page_breadcrumbs` | Include breadcrumb links at top of page |\n\n"
+    "| `export.confluence_url_in_frontmatter` | Include Confluence page URL in YAML "
+    "front matter: `none`, `webui`, `tinyui`, `both` |\n\n"
     "| `export.enable_jira_enrichment` | Fetch Jira data for enriched links |\n\n"
     "| `export.attachments_export` | Which attachments to download:"
     " `referenced` (default), `all`, `disabled` |\n\n"

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -164,6 +164,25 @@ def _extract_base_url(url: str) -> str:
     return normalize_instance_url(base)
 
 
+def _join_confluence_link(data: JsonResponse, key: str) -> str:
+    links = data.get("_links", {})
+    if not isinstance(links, dict):
+        return ""
+    base = links.get("base")
+    rel = links.get(key)
+    if not isinstance(base, str) or not isinstance(rel, str) or not base or not rel:
+        return ""
+    return f"{base.rstrip('/')}/{rel.lstrip('/')}"
+
+
+def _get_web_url(data: JsonResponse) -> str:
+    return _join_confluence_link(data, "webui")
+
+
+def _get_tiny_url(data: JsonResponse) -> str:
+    return _join_confluence_link(data, "tinyui")
+
+
 _JIRA_ROUTE_SEGMENTS = {
     "agile",
     "backlog",
@@ -823,6 +842,8 @@ def _parse_image_captions(storage_xml: str) -> dict[str, str]:
 
 class Page(Document):
     id: int
+    web_url: str = ""
+    tiny_url: str = ""
     body: str
     body_export: str
     editor2: str
@@ -1150,6 +1171,8 @@ class Page(Document):
         return cls(
             base_url=base_url,
             id=data.get("id", 0),
+            web_url=_get_web_url(data),
+            tiny_url=_get_tiny_url(data),
             title=data.get("title", ""),
             space=Space.from_key(
                 data.get("_expandable", {}).get("space", "").split("/")[-1], base_url
@@ -1331,6 +1354,7 @@ class Page(Document):
         def front_matter(self) -> str:
             indent = self.options["front_matter_indent"]
             self.set_page_properties(tags=self.labels)
+            self._add_confluence_url_properties()
 
             if not self.page_properties:
                 return ""
@@ -1339,6 +1363,21 @@ class Page(Document):
             # Indent the root level list items
             yml = re.sub(r"^( *)(- )", r"\1" + " " * indent + r"\2", yml, flags=re.MULTILINE)
             return f"---\n{yml}\n---\n"
+
+        def _add_confluence_url_properties(self) -> None:
+            mode = settings.export.confluence_url_in_frontmatter
+            if mode == "none":
+                return
+
+            if mode in ("webui", "both") and self.page.web_url:
+                key = sanitize_key("confluence_webui_url")
+                if key not in self.page_properties:
+                    self.page_properties[key] = self.page.web_url
+
+            if mode in ("tinyui", "both") and self.page.tiny_url:
+                key = sanitize_key("confluence_tinyui_url")
+                if key not in self.page_properties:
+                    self.page_properties[key] = self.page.tiny_url
 
         @property
         def breadcrumbs(self) -> str:

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -460,6 +460,19 @@ class ExportConfig(BaseModel):
             "    with their page properties as frontmatter; falls back to frozen on failure"
         ),
     )
+    confluence_url_in_frontmatter: Literal["none", "webui", "tinyui", "both"] = Field(
+        default="none",
+        title="Confluence URL in Front Matter",
+        description=(
+            "Whether to include the original Confluence page URL in YAML front matter.\n"
+            "  none: do not include (default)\n"
+            "  webui: include human-readable URL as `confluence_webui_url`\n"
+            "  tinyui: include stable short permalink as `confluence_tinyui_url`\n"
+            "  both: include both fields\n"
+            "If a Page Properties macro already defines one of these keys, "
+            "the macro value takes precedence."
+        ),
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -23,6 +23,8 @@ class MockPage:
         self.title = "Test Page"
         self.html = ""
         self.body_storage = ""
+        self.web_url = ""
+        self.tiny_url = ""
         self.labels = []
         self.ancestors = []
 
@@ -836,6 +838,122 @@ class TestPagePropertiesMigration:
 
         config = ExportConfig()
         assert config.page_properties_format == "frontmatter_and_table"
+
+
+class TestConfluenceUrlInFrontmatter:
+    """Confluence page URLs render to YAML front matter according to the setting."""
+
+    _WEBUI = "https://example.atlassian.net/wiki/spaces/TEST/pages/123/Test+Page"
+    _TINYUI = "https://example.atlassian.net/wiki/x/AbCdEf"
+
+    def _converter(self, *, with_urls: bool = True) -> Page.Converter:
+        page = MockPage()
+        if with_urls:
+            page.web_url = self._WEBUI
+            page.tiny_url = self._TINYUI
+        return Page.Converter(page)
+
+    def test_get_web_url_combines_base_and_webui(self) -> None:
+        from confluence_markdown_exporter.confluence import _get_web_url
+
+        data = {
+            "_links": {
+                "base": "https://example.atlassian.net/wiki",
+                "webui": "/spaces/TEST/pages/123/Test+Page",
+            }
+        }
+        assert _get_web_url(data) == self._WEBUI
+
+    def test_get_tiny_url_combines_base_and_tinyui(self) -> None:
+        from confluence_markdown_exporter.confluence import _get_tiny_url
+
+        data = {
+            "_links": {
+                "base": "https://example.atlassian.net/wiki",
+                "tinyui": "/x/AbCdEf",
+            }
+        }
+        assert _get_tiny_url(data) == self._TINYUI
+
+    def test_helpers_strip_redundant_separators(self) -> None:
+        from confluence_markdown_exporter.confluence import _get_web_url
+
+        data = {
+            "_links": {
+                "base": "https://example.atlassian.net/wiki/",
+                "webui": "/spaces/TEST/pages/123/Test+Page",
+            }
+        }
+        assert _get_web_url(data) == self._WEBUI
+
+    def test_helpers_return_empty_when_links_missing(self) -> None:
+        from confluence_markdown_exporter.confluence import _get_tiny_url
+        from confluence_markdown_exporter.confluence import _get_web_url
+
+        assert _get_web_url({}) == ""
+        assert _get_tiny_url({}) == ""
+
+    def test_helpers_return_empty_when_links_not_dict(self) -> None:
+        from confluence_markdown_exporter.confluence import _get_tiny_url
+        from confluence_markdown_exporter.confluence import _get_web_url
+
+        assert _get_web_url({"_links": "broken"}) == ""
+        assert _get_tiny_url({"_links": None}) == ""
+
+    def test_helpers_return_empty_when_base_or_rel_missing(self) -> None:
+        from confluence_markdown_exporter.confluence import _get_web_url
+
+        assert _get_web_url({"_links": {"base": "https://example.com"}}) == ""
+        assert _get_web_url({"_links": {"webui": "/spaces/TEST"}}) == ""
+
+    def test_frontmatter_contains_webui_url_when_mode_webui(self) -> None:
+        converter = self._converter()
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.confluence_url_in_frontmatter = "webui"
+            result = converter.front_matter
+        assert f"confluence_webui_url: {self._WEBUI}" in result
+        assert "confluence_tinyui_url" not in result
+
+    def test_frontmatter_contains_tinyui_url_when_mode_tinyui(self) -> None:
+        converter = self._converter()
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.confluence_url_in_frontmatter = "tinyui"
+            result = converter.front_matter
+        assert f"confluence_tinyui_url: {self._TINYUI}" in result
+        assert "confluence_webui_url" not in result
+
+    def test_frontmatter_contains_both_when_mode_both(self) -> None:
+        converter = self._converter()
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.confluence_url_in_frontmatter = "both"
+            result = converter.front_matter
+        assert f"confluence_webui_url: {self._WEBUI}" in result
+        assert f"confluence_tinyui_url: {self._TINYUI}" in result
+
+    def test_frontmatter_omits_urls_when_mode_none(self) -> None:
+        converter = self._converter()
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.confluence_url_in_frontmatter = "none"
+            result = converter.front_matter
+        assert "confluence_webui_url" not in result
+        assert "confluence_tinyui_url" not in result
+
+    def test_frontmatter_skips_when_url_value_is_empty(self) -> None:
+        converter = self._converter(with_urls=False)
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.confluence_url_in_frontmatter = "both"
+            result = converter.front_matter
+        assert "confluence_webui_url" not in result
+        assert "confluence_tinyui_url" not in result
+
+    def test_macro_value_takes_precedence_over_extracted_url(self) -> None:
+        converter = self._converter()
+        converter.page_properties["confluence_webui_url"] = "manual-override"
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.confluence_url_in_frontmatter = "webui"
+            result = converter.front_matter
+        assert "confluence_webui_url: manual-override" in result
+        assert self._WEBUI not in result
 
 
 class TestPagePropertiesReportDataview:

--- a/tests/unit/utils/test_app_data_store_env.py
+++ b/tests/unit/utils/test_app_data_store_env.py
@@ -53,6 +53,12 @@ class TestEnvVarOverrides:
             settings = get_settings()
         assert settings.export.attachments_export == "all"
 
+    def test_confluence_url_in_frontmatter_env_override(self) -> None:
+        """CME_EXPORT__CONFLUENCE_URL_IN_FRONTMATTER overrides confluence_url_in_frontmatter."""
+        with patch.dict(os.environ, {"CME_EXPORT__CONFLUENCE_URL_IN_FRONTMATTER": "both"}):
+            settings = get_settings()
+        assert settings.export.confluence_url_in_frontmatter == "both"
+
     def test_env_var_does_not_persist(self) -> None:
         """ENV var override is session-only and does not alter the JSON config file."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
# PR: Add Confluence page URL to YAML front matter

> Picks up the open feature work from [#206](https://github.com/Spenhouet/confluence-markdown-exporter/pull/206). Same idea — original Confluence page URL in exported markdown — but rebuilt around the maintainer's front matter request and extended to expose both URL variants the API provides.

## Title

```
Add Confluence page URL to YAML front matter
```

## Body

## Summary

Adds a single new setting,
`export.confluence_url_in_frontmatter: Literal["none", "webui", "tinyui", "both"]`
(default `"none"` — no behaviour change unless opted in), that writes the
original Confluence page URL into the YAML front matter of each exported
markdown file.

| Mode     | Front matter keys added                                              |
| -------- | -------------------------------------------------------------------- |
| `none`   | — (default; nothing changes)                                         |
| `webui`  | `confluence_webui_url` — human-readable URL (changes on rename/move) |
| `tinyui` | `confluence_tinyui_url` — stable short permalink based on page ID    |
| `both`   | both of the above                                                    |

**Why.** Picks up the discussion from [#206](https://github.com/Spenhouet/confluence-markdown-exporter/pull/206). The original PR appended the URL as a plain-text line to the body; the maintainer asked for the front matter via the existing `set_page_properties` mechanism instead. This PR implements that and also exposes the `tinyui` permalink — `webui` URLs encode the space key and current page title and break on rename or move, while `tinyui` paths (`/wiki/x/<base62>`) only encode the immutable page ID and survive both. Letting the user pick `webui` / `tinyui` / `both` keeps the choice in their hands without forcing one trade-off.

**What changes:**

- Three new helpers in `confluence.py` — `_join_confluence_link`,
  `_get_web_url`, `_get_tiny_url` — extract `_links.base` plus
  `_links.{webui|tinyui}` defensively (return `""` if either side is
  missing or the wrong type).
- `Page` gains two new fields, `web_url: str = ""` and `tiny_url: str = ""`,
  populated in `Page.from_json`. The existing fallback constructors in
  `Page.from_id` keep working unchanged because the defaults are empty
  strings.
- `Page.Converter` gains a new `_add_confluence_url_properties()` method
  that is called from the existing `front_matter` property right after
  `set_page_properties(tags=...)`. It writes the URLs through the same
  `page_properties` dict that the rest of the front matter machinery
  already uses.
- New Pydantic field
  `ExportConfig.confluence_url_in_frontmatter`. Modelled after the
  existing `page_properties_format` Literal (same docstring style, same
  default-disabled discipline).
- README, the `cme config` epilog table, and the Pydantic
  `description=` text are all updated to document the four modes.

**Collision safety.** If a Page Properties macro on the page already
populated `confluence_webui_url` or `confluence_tinyui_url` (for
example because the page author maintains the URL by hand inside a
Page Properties macro), the macro value wins —
`_add_confluence_url_properties` checks
`if key not in self.page_properties` before assigning. This is the only
reason it bypasses `set_page_properties()` and writes the dict
directly: that helper would unconditionally overwrite.

**What is intentionally not changed:**

- The body of the page — no plain-text URL line is injected anywhere.
  PR #206's fallback approach is dropped.
- Default behaviour — `"none"` is the default, so existing exports are
  bit-identical.
- Internal raw-path fields some downstream forks expose (`webui_link`,
  `tinyui_link`) are not added; the public surface is just the resolved
  `web_url` / `tiny_url` strings on `Page`.
- No env-var migration: the feature is new; there is nothing legacy to
  migrate.

> Implementation written by Claude Sonnet 4.6 from a hand-written plan;
> reviewed and tested manually before opening this PR.

## Test Plan

New tests in `tests/unit/test_confluence.py`
(`TestConfluenceUrlInFrontmatter`, 12 tests):

- URL helpers: `_get_web_url` / `_get_tiny_url` join `_links.base` with
  the relative path; trailing-slash + leading-slash combinations are
  normalised; return `""` when `_links` is missing, when it isn't a
  dict, or when either side of the join is missing.
- Front matter: `webui` / `tinyui` / `both` modes each emit only the
  expected key(s); `none` emits neither; empty `Page.web_url` /
  `Page.tiny_url` short-circuit cleanly without writing empty values.
- Macro precedence: when `page_properties["confluence_webui_url"]` is
  already populated (simulating a Page Properties macro hit), the API
  URL is **not** injected and the existing value is preserved.

New test in `tests/unit/utils/test_app_data_store_env.py`:

- `test_confluence_url_in_frontmatter_env_override`: verifies
  `CME_EXPORT__CONFLUENCE_URL_IN_FRONTMATTER=both` reaches
  `settings.export.confluence_url_in_frontmatter`.

Automated:

```bash
uv run ruff check .            # clean
uv run pytest tests/unit/ -q   # 337 passed
```

**Manually tested** against a live Confluence page:

```bash
# default — no URL in front matter
CME_EXPORT__OUTPUT_PATH=/tmp/cme-none \
  uv run cme pages <page-url>
grep -E "confluence_(webui|tinyui)_url:" /tmp/cme-none/**/*.md
# (no hits)

# both — both URLs land in front matter
CME_EXPORT__OUTPUT_PATH=/tmp/cme-both \
  CME_EXPORT__CONFLUENCE_URL_IN_FRONTMATTER=both \
  uv run cme pages <page-url>
grep -E "confluence_(webui|tinyui)_url:" /tmp/cme-both/**/*.md
# confluence_webui_url:  https://<host>/wiki/spaces/<KEY>/pages/<id>/<Title>
# confluence_tinyui_url: https://<host>/wiki/x/<short>
```

Macro-precedence smoke test: a page with a Page Properties macro whose
header sanitises to `confluence_webui_url` must export the macro value,
not the API URL.
