### PR TITLE
Update Known Issues entry for missing attachment fileId

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,7 +736,7 @@ It generally was tested on:
 
 ## Known Issues and Limitations
 
-1. **Missing Attachment File ID on Server**: For some Confluence Server version/configuration the attachment file ID might not be provided (https://github.com/Spenhouet/confluence-markdown-exporter/issues/39). In the default configuration, this is used for the export path. Solution: Adjust the attachment path in the export config and use the `{attachment_id}` or `{attachment_title}{attachment_extension}` instead.
+1. **Missing Attachment File ID on Server**: For some Confluence Server versions / configurations, the attachment file ID is not returned by the API (https://github.com/Spenhouet/confluence-markdown-exporter/issues/39). In that case, `{attachment_file_id}` automatically falls back to the content id, so the default `export.attachment_path` template still produces unique filenames out of the box. If you prefer human-readable filenames over numeric IDs, set `export.attachment_path` to use `{attachment_title}{attachment_extension}`, e.g. `{space_name}/attachments/{attachment_title}{attachment_extension}`.
 2. **Connection Issues when behind Proxy or VPN**: There might be connection issues if your Confluence Server is behind a proxy or VPN (https://github.com/Spenhouet/confluence-markdown-exporter/issues/38). If you experience issues, help to fix this is appreciated.
 
 ## Contributing


### PR DESCRIPTION
## Summary

Follow-up to #224. That PR fixed the underlying problem from #39 by making `{attachment_file_id}` fall back to the content id on Confluence Server / Data Center, so the default `export.attachment_path` now produces unique filenames out of the box. The first entry under _Known Issues and Limitations_ in the README still describes the manual workaround as the solution, though, and is therefore out of date.

This PR rewrites that entry so it:

- mentions the automatic fallback (no override needed by default),
- recommends `{attachment_title}{attachment_extension}` as an alternative for users who prefer human-readable filenames over numeric IDs,
- keeps the link to #39 as historical context.

No code changes; documentation only. The default template is unchanged.

> Wording prepared by Claude Opus 4.7 from a hand-written plan; reviewed manually before opening this PR.

## Test Plan

- `git diff` shows only the one entry under _Known Issues and Limitations_ is changed.
- README renders cleanly on GitHub (Markdown list, inline code spans for template variables and example path).