### PR TITLE
Use unique page title ref when ambiguous

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -61,6 +61,7 @@ from confluence_markdown_exporter.utils.export import sanitize_key
 from confluence_markdown_exporter.utils.export import save_file
 from confluence_markdown_exporter.utils.lockfile import AttachmentEntry
 from confluence_markdown_exporter.utils.lockfile import LockfileManager
+from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
 from confluence_markdown_exporter.utils.rich_console import ExportStats
 from confluence_markdown_exporter.utils.rich_console import console
 from confluence_markdown_exporter.utils.rich_console import get_stats
@@ -1776,7 +1777,12 @@ class Page(Document):
                 )
                 return f"[Page not accessible (ID: {page_id})]"
 
+            PageTitleRegistry.register(int(page.id), page.title)
+
             if settings.export.page_href == "wiki":
+                if PageTitleRegistry.is_ambiguous(page.title):
+                    vault_path = page.export_path.with_suffix("").as_posix()
+                    return f"[[{vault_path}|{page.title}]]"
                 return f"[[{page.title}]]"
 
             page_path = self._get_path_for_href(page.export_path, settings.export.page_href)
@@ -2555,6 +2561,8 @@ def export_pages(pages: list["Page | Descendant"]) -> None:
     """
     # Mark all pages as seen so cleanup skips API checks for unchanged pages
     LockfileManager.mark_seen([p.id for p in pages])
+    for p in pages:
+        PageTitleRegistry.register(int(p.id), p.title)
     pages_to_export = [page for page in pages if LockfileManager.should_export(page)]
 
     skipped_count = len(pages) - len(pages_to_export)

--- a/confluence_markdown_exporter/main.py
+++ b/confluence_markdown_exporter/main.py
@@ -182,6 +182,7 @@ def pages(
 ) -> None:
     from confluence_markdown_exporter.confluence import Page
     from confluence_markdown_exporter.confluence import sync_removed_pages
+    from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
 
     _init_logging()
     stats = reset_stats(total=len(page_urls))
@@ -189,9 +190,14 @@ def pages(
         LockfileManager.init()
 
         exported_urls: set[str] = set()
+        fetched_pages: list[Page] = []
         for page_url in page_urls:
             with console.status(f"[dim]Fetching [highlight]{page_url}[/highlight]…[/dim]"):
                 page = Page.from_url(page_url)
+            PageTitleRegistry.register(int(page.id), page.title)
+            fetched_pages.append(page)
+
+        for page in fetched_pages:
             LockfileManager.mark_seen([page.id])
             if not LockfileManager.should_export(page):
                 stats.inc_skipped()

--- a/confluence_markdown_exporter/utils/lockfile.py
+++ b/confluence_markdown_exporter/utils/lockfile.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import ValidationError
 
+from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
 from confluence_markdown_exporter.utils.rich_console import get_stats
 
 if TYPE_CHECKING:
@@ -215,6 +216,12 @@ class LockfileManager:
         cls._lock = ConfluenceLock.load(cls._lockfile_path)
         cls._all_entries_snapshot = dict(cls._lock.all_pages())
         cls._seen_page_ids = set()
+        PageTitleRegistry.reset()
+        for pid, entry in cls._all_entries_snapshot.items():
+            try:
+                PageTitleRegistry.register(int(pid), entry.title)
+            except (TypeError, ValueError):
+                continue
         logger.debug(
             "Lockfile initialized: %s (%d tracked page(s))",
             cls._lockfile_path,
@@ -243,6 +250,7 @@ class LockfileManager:
             cls._lock.add_page(page, attachment_entries)
             cls._lock.save(cls._lockfile_path)
             cls._seen_page_ids.add(str(page.id))
+        PageTitleRegistry.register(int(page.id), page.title)
 
     @classmethod
     def mark_seen(cls, page_ids: list[int]) -> None:

--- a/confluence_markdown_exporter/utils/page_registry.py
+++ b/confluence_markdown_exporter/utils/page_registry.py
@@ -1,0 +1,56 @@
+"""Cross-space page title registry for link disambiguation.
+
+Confluence enforces page-title uniqueness per space, not across spaces.
+When pages from multiple spaces are exported into the same vault, two
+pages can share a title — Obsidian's wiki link ``[[Title]]`` then
+resolves ambiguously. This registry tracks known page titles so the
+Markdown converter can emit a path-qualified wiki link
+(``[[path/to/file|Title]]``) when a collision is detected.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import ClassVar
+
+
+class PageTitleRegistry:
+    """Track page-id -> title mappings to detect cross-page title collisions.
+
+    Populated from the lockfile snapshot at run start and from each
+    page list before export workers begin so collisions are known
+    before any link rendering.
+    """
+
+    _entries: ClassVar[dict[int, str]] = {}
+    _title_counts: ClassVar[dict[str, int]] = {}
+    _lock: ClassVar[threading.Lock] = threading.Lock()
+
+    @classmethod
+    def reset(cls) -> None:
+        with cls._lock:
+            cls._entries.clear()
+            cls._title_counts.clear()
+
+    @classmethod
+    def register(cls, page_id: int, title: str) -> None:
+        if not page_id or not title:
+            return
+        with cls._lock:
+            old = cls._entries.get(page_id)
+            if old == title:
+                return
+            if old is not None:
+                cls._title_counts[old] -= 1
+                if cls._title_counts[old] <= 0:
+                    cls._title_counts.pop(old, None)
+            cls._entries[page_id] = title
+            cls._title_counts[title] = cls._title_counts.get(title, 0) + 1
+
+    @classmethod
+    def is_ambiguous(cls, title: str) -> bool:
+        return cls._title_counts.get(title, 0) > 1
+
+    @classmethod
+    def title_count(cls, title: str) -> int:
+        return cls._title_counts.get(title, 0)

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1084,3 +1084,119 @@ class TestAttachmentTemplateVars:
             path2 = att2.export_path
 
         assert path1 != path2
+
+
+class TestWikiLinkDisambiguation:
+    """Wiki page links use a vault-relative path when titles collide across spaces."""
+
+    def _make_target_page(self, page_id: int, title: str, space_key: str) -> Page:
+        space = Space(
+            base_url="https://example.com",
+            key=space_key,
+            name=space_key,
+            description="",
+            homepage=0,
+        )
+        version = Version(
+            number=1,
+            by=User(
+                account_id="u1",
+                display_name="User",
+                username="user",
+                public_name="",
+                email="",
+            ),
+            when="2024-01-01T00:00:00Z",
+            friendly_when="Jan 1",
+        )
+        return Page(
+            base_url="https://example.com",
+            id=page_id,
+            title=title,
+            space=space,
+            ancestors=[],
+            version=version,
+            body="",
+            body_export="",
+            editor2="",
+            body_storage="",
+            labels=[],
+            attachments=[],
+        )
+
+    def test_unique_title_emits_short_wiki_link(self) -> None:
+        from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
+
+        PageTitleRegistry.reset()
+        target = self._make_target_page(101, "Unique Page", "ALPHA")
+        PageTitleRegistry.register(target.id, target.title)
+
+        source = _make_page(body="", body_export="", attachments=[])
+
+        with (
+            patch("confluence_markdown_exporter.confluence.Page.from_id", return_value=target),
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
+            s.export.page_href = "wiki"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            conv = Page.Converter(source)
+            html = '<a data-linked-resource-type="page" data-linked-resource-id="101">x</a>'
+            result = conv.convert(html).strip()
+
+        PageTitleRegistry.reset()
+        assert result == "[[Unique Page]]"
+
+    def test_colliding_title_emits_path_qualified_wiki_link(self) -> None:
+        from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
+
+        PageTitleRegistry.reset()
+        target_alpha = self._make_target_page(201, "Shared Title", "ALPHA")
+        target_beta = self._make_target_page(202, "Shared Title", "BETA")
+        PageTitleRegistry.register(target_alpha.id, target_alpha.title)
+        PageTitleRegistry.register(target_beta.id, target_beta.title)
+
+        source = _make_page(body="", body_export="", attachments=[])
+
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.Page.from_id",
+                return_value=target_alpha,
+            ),
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
+            s.export.page_href = "wiki"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            conv = Page.Converter(source)
+            html = '<a data-linked-resource-type="page" data-linked-resource-id="201">x</a>'
+            result = conv.convert(html).strip()
+
+        PageTitleRegistry.reset()
+        assert result == "[[ALPHA/Shared Title|Shared Title]]"
+
+    def test_relative_link_unaffected(self) -> None:
+        from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
+
+        PageTitleRegistry.reset()
+        target_alpha = self._make_target_page(201, "Shared Title", "ALPHA")
+        target_beta = self._make_target_page(202, "Shared Title", "BETA")
+        PageTitleRegistry.register(target_alpha.id, target_alpha.title)
+        PageTitleRegistry.register(target_beta.id, target_beta.title)
+
+        source = _make_page(body="", body_export="", attachments=[])
+
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.Page.from_id",
+                return_value=target_alpha,
+            ),
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
+            s.export.page_href = "relative"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            conv = Page.Converter(source)
+            html = '<a data-linked-resource-type="page" data-linked-resource-id="201">x</a>'
+            result = conv.convert(html).strip()
+
+        PageTitleRegistry.reset()
+        assert "Shared%20Title.md" in result
+        assert result.startswith("[Shared Title](")

--- a/tests/unit/utils/test_page_registry.py
+++ b/tests/unit/utils/test_page_registry.py
@@ -1,0 +1,63 @@
+"""Tests for PageTitleRegistry collision detection."""
+
+from __future__ import annotations
+
+import pytest
+
+from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> None:
+    PageTitleRegistry.reset()
+    yield
+    PageTitleRegistry.reset()
+
+
+def test_unique_title_not_ambiguous() -> None:
+    PageTitleRegistry.register(1, "Shared Title")
+    assert PageTitleRegistry.is_ambiguous("Shared Title") is False
+
+
+def test_two_pages_same_title_ambiguous() -> None:
+    PageTitleRegistry.register(1, "Shared Title")
+    PageTitleRegistry.register(2, "Shared Title")
+    assert PageTitleRegistry.is_ambiguous("Shared Title") is True
+
+
+def test_unknown_title_not_ambiguous() -> None:
+    assert PageTitleRegistry.is_ambiguous("Never Seen") is False
+
+
+def test_re_register_same_id_does_not_inflate_count() -> None:
+    PageTitleRegistry.register(1, "Shared Title")
+    PageTitleRegistry.register(1, "Shared Title")
+    PageTitleRegistry.register(1, "Shared Title")
+    assert PageTitleRegistry.is_ambiguous("Shared Title") is False
+    assert PageTitleRegistry.title_count("Shared Title") == 1
+
+
+def test_renaming_page_updates_counts() -> None:
+    PageTitleRegistry.register(1, "Old Title")
+    PageTitleRegistry.register(2, "Old Title")
+    assert PageTitleRegistry.is_ambiguous("Old Title") is True
+
+    PageTitleRegistry.register(1, "New Title")
+    assert PageTitleRegistry.is_ambiguous("Old Title") is False
+    assert PageTitleRegistry.title_count("Old Title") == 1
+    assert PageTitleRegistry.title_count("New Title") == 1
+
+
+def test_reset_clears_state() -> None:
+    PageTitleRegistry.register(1, "X")
+    PageTitleRegistry.register(2, "X")
+    PageTitleRegistry.reset()
+    assert PageTitleRegistry.is_ambiguous("X") is False
+    assert PageTitleRegistry.title_count("X") == 0
+
+
+def test_blank_inputs_ignored() -> None:
+    PageTitleRegistry.register(0, "X")
+    PageTitleRegistry.register(1, "")
+    assert PageTitleRegistry.title_count("X") == 0
+    assert PageTitleRegistry.title_count("") == 0


### PR DESCRIPTION
## Summary

When multiple spaces are exported and contain a page with the same name, the wiki link is ambiguous. Detect these cases and resolve to a fully qualified ref.

## Test Plan

Tests added.
