### PR TITLE
Strip excerpt include title

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1343,7 +1343,8 @@ class Page(Document):
 
         @property
         def markdown(self) -> str:
-            md_body = self.convert(self.page.html)
+            html = self._strip_excerpt_include_panel_titles(self.page.html)
+            md_body = self.convert(html)
             md_body = self._escape_template_placeholders(md_body)
             markdown = f"{self.front_matter}\n"
             if settings.export.page_breadcrumbs:
@@ -2196,6 +2197,33 @@ class Page(Document):
                 return super().convert_div(el, text, parent_tags)  # type: ignore[misc]
 
             return f"\n![[{target_title}]]\n\n"
+
+        def _strip_excerpt_include_panel_titles(self, html: str) -> str:
+            """Strip the source-page-title panel from `excerpt-include` bodies.
+
+            Confluence prepends a panel whose plain text is the source page
+            title to `excerpt-include` body.view content unless `nopanel=true`.
+            Without this, the converter emits the title as a stray bold line
+            above the included content.
+            """
+            soup = BeautifulSoup(html, "html.parser")
+            title_tags = ("p", "h1", "h2", "h3", "h4", "h5", "h6")
+            for el in soup.find_all(attrs={"data-macro-name": "excerpt-include"}):
+                macro_id = el.get("data-macro-id")
+                if not isinstance(macro_id, str):
+                    continue
+                target_title = self._extract_include_target_title(macro_id)
+                if not target_title:
+                    continue
+                first_tag = next((c for c in el.children if isinstance(c, Tag)), None)
+                if first_tag is None:
+                    continue
+                if (
+                    first_tag.name in title_tags
+                    and first_tag.get_text(strip=True) == target_title
+                ):
+                    first_tag.decompose()
+            return str(soup)
 
         def _extract_include_target_title(self, macro_id: str) -> str | None:
             """Resolve the target page title for an `include` / `excerpt-include` macro.

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2201,29 +2201,26 @@ class Page(Document):
         def _strip_excerpt_include_panel_titles(self, html: str) -> str:
             """Strip the source-page-title panel from `excerpt-include` bodies.
 
-            Confluence prepends a panel whose plain text is the source page
-            title to `excerpt-include` body.view content unless `nopanel=true`.
-            Without this, the converter emits the title as a stray bold line
-            above the included content.
+            Confluence's `excerpt-include` body.view wraps the included
+            content in a panel whose `panelHeader` is the source page title
+            unless `nopanel=true`. The `panelContent` div holds the actual
+            body. We unwrap to leave only the body.
             """
             soup = BeautifulSoup(html, "html.parser")
-            title_tags = ("p", "h1", "h2", "h3", "h4", "h5", "h6")
             for el in soup.find_all(attrs={"data-macro-name": "excerpt-include"}):
-                macro_id = el.get("data-macro-id")
-                if not isinstance(macro_id, str):
-                    continue
-                target_title = self._extract_include_target_title(macro_id)
-                if not target_title:
-                    continue
-                first_tag = next((c for c in el.children if isinstance(c, Tag)), None)
-                if first_tag is None:
-                    continue
-                if (
-                    first_tag.name in title_tags
-                    and first_tag.get_text(strip=True) == target_title
-                ):
-                    first_tag.decompose()
+                self._unwrap_excerpt_include_panel(el)
             return str(soup)
+
+        def _unwrap_excerpt_include_panel(self, el: Tag) -> None:
+            classes = el.get("class") or []
+            if not isinstance(classes, list) or "panel" not in classes:
+                return
+            header = el.find("div", class_="panelHeader")
+            if isinstance(header, Tag):
+                header.decompose()
+            content = el.find("div", class_="panelContent")
+            if isinstance(content, Tag):
+                content.unwrap()
 
         def _extract_include_target_title(self, macro_id: str) -> str | None:
             """Resolve the target page title for an `include` / `excerpt-include` macro.

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2179,9 +2179,6 @@ class Page(Document):
             When `include_macro = inline` (default), the body_view content is
             already expanded — fall through to normal div processing to render it.
             """
-            if settings.export.include_macro != "transclusion":
-                return super().convert_div(el, text, parent_tags)  # type: ignore[misc]
-
             macro_name = str(el.get("data-macro-name", ""))
             macro_id = el.get("data-macro-id")
 
@@ -2189,14 +2186,24 @@ class Page(Document):
             if macro_id and isinstance(macro_id, str):
                 target_title = self._extract_include_target_title(macro_id)
 
-            if not target_title:
+            if settings.export.include_macro == "transclusion" and target_title:
+                return f"\n![[{target_title}]]\n\n"
+
+            if settings.export.include_macro == "transclusion":
                 logger.warning(
                     f"{macro_name} macro found but target page title could not be resolved; "
                     f"falling back to inline content"
                 )
-                return super().convert_div(el, text, parent_tags)  # type: ignore[misc]
 
-            return f"\n![[{target_title}]]\n\n"
+            inline = super().convert_div(el, text, parent_tags)  # type: ignore[misc]
+            if macro_name == "excerpt-include":
+                title_note = f" from page '{target_title}'" if target_title else ""
+                return (
+                    f"\n<!-- excerpt start{title_note} -->\n"
+                    f"{inline}"
+                    f"\n<!-- excerpt end{title_note} -->\n\n"
+                )
+            return inline
 
         def _strip_excerpt_include_panel_titles(self, html: str) -> str:
             """Strip the source-page-title panel from `excerpt-include` bodies.

--- a/tests/unit/test_include_macro_conversion.py
+++ b/tests/unit/test_include_macro_conversion.py
@@ -97,6 +97,50 @@ def test_include_macro_inline_mode(mock_settings: MagicMock) -> None:
 
 
 @patch("confluence_markdown_exporter.confluence.settings")
+def test_excerpt_include_inline_strips_source_page_title_panel(
+    mock_settings: MagicMock,
+) -> None:
+    mock_settings.export.include_document_title = False
+    mock_settings.export.page_breadcrumbs = False
+    mock_settings.export.include_macro = "inline"
+
+    converter = Page.Converter(_make_page(EXCERPT_INCLUDE_EDITOR2))
+
+    html = (
+        '<div data-macro-name="excerpt-include" data-macro-id="macro-excerpt-1">'
+        "<p><strong>Source Page</strong></p>"
+        "<table><tr><td>body cell</td></tr></table>"
+        "</div>"
+    )
+
+    stripped = converter._strip_excerpt_include_panel_titles(html)
+
+    assert "<strong>Source Page</strong>" not in stripped
+    assert "body cell" in stripped
+
+
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_excerpt_include_inline_keeps_body_when_no_title_panel(
+    mock_settings: MagicMock,
+) -> None:
+    mock_settings.export.include_document_title = False
+    mock_settings.export.page_breadcrumbs = False
+    mock_settings.export.include_macro = "inline"
+
+    converter = Page.Converter(_make_page(EXCERPT_INCLUDE_EDITOR2))
+
+    html = (
+        '<div data-macro-name="excerpt-include" data-macro-id="macro-excerpt-1">'
+        "<p>actual excerpt body</p>"
+        "</div>"
+    )
+
+    stripped = converter._strip_excerpt_include_panel_titles(html)
+
+    assert "actual excerpt body" in stripped
+
+
+@patch("confluence_markdown_exporter.confluence.settings")
 def test_include_macro_transclusion_falls_back_when_target_unresolvable(
     mock_settings: MagicMock,
 ) -> None:

--- a/tests/unit/test_include_macro_conversion.py
+++ b/tests/unit/test_include_macro_conversion.py
@@ -107,20 +107,23 @@ def test_excerpt_include_inline_strips_source_page_title_panel(
     converter = Page.Converter(_make_page(EXCERPT_INCLUDE_EDITOR2))
 
     html = (
-        '<div data-macro-name="excerpt-include" data-macro-id="macro-excerpt-1">'
-        "<p><strong>Source Page</strong></p>"
-        "<table><tr><td>body cell</td></tr></table>"
+        '<div class="panel conf-macro output-inline" data-macro-name="excerpt-include"'
+        ' data-macro-id="macro-excerpt-1">'
+        '<div class="panelHeader"><b>Source Page</b></div>'
+        '<div class="panelContent"><table><tr><td>body cell</td></tr></table></div>'
         "</div>"
     )
 
     stripped = converter._strip_excerpt_include_panel_titles(html)
 
-    assert "<strong>Source Page</strong>" not in stripped
+    assert "Source Page" not in stripped
+    assert "panelHeader" not in stripped
+    assert "panelContent" not in stripped
     assert "body cell" in stripped
 
 
 @patch("confluence_markdown_exporter.confluence.settings")
-def test_excerpt_include_inline_keeps_body_when_no_title_panel(
+def test_excerpt_include_inline_keeps_body_when_no_panel(
     mock_settings: MagicMock,
 ) -> None:
     mock_settings.export.include_document_title = False
@@ -130,9 +133,8 @@ def test_excerpt_include_inline_keeps_body_when_no_title_panel(
     converter = Page.Converter(_make_page(EXCERPT_INCLUDE_EDITOR2))
 
     html = (
-        '<div data-macro-name="excerpt-include" data-macro-id="macro-excerpt-1">'
-        "<p>actual excerpt body</p>"
-        "</div>"
+        '<span class="conf-macro output-inline" data-macro-name="excerpt-include"'
+        ' data-macro-id="macro-excerpt-1">actual excerpt body</span>'
     )
 
     stripped = converter._strip_excerpt_include_panel_titles(html)


### PR DESCRIPTION
## Summary

The excerpt include macro title was printed as bold text above the excerpt. This is usually not what one wants.

## Test Plan

Test adjusted.
