### PR TITLE
Resolve absolute Confluence URLs to page links

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1754,10 +1754,26 @@ class Page(Document):
                 link = self.convert_attachment_link(el, text, parent_tags)
                 # convert_attachment_link may return None if the attachment meta is incomplete
                 return link or f"[{text}]({el.get('href')})"
-            if match := parse_confluence_path(str(el.get("href", ""))):
-                if match.page_id:
-                    return self.convert_page_link(match.page_id)
-            if (href := str(el.get("href", ""))).startswith("#"):
+            href_str = str(el.get("href", ""))
+            if href_str:
+                parsed_href = urlparse(href_str)
+                base_host = urlparse(getattr(self.page, "base_url", "") or "").hostname
+                if not parsed_href.hostname or parsed_href.hostname == base_host:
+                    query_params = urllib.parse.parse_qs(parsed_href.query)
+                    page_id_param = next(
+                        (
+                            values[0]
+                            for key, values in query_params.items()
+                            if key.lower() == "pageid" and values and values[0]
+                        ),
+                        None,
+                    )
+                    if page_id_param and page_id_param.isdigit():
+                        return self.convert_page_link(int(page_id_param))
+                    if match := parse_confluence_path(parsed_href.path):
+                        if match.page_id:
+                            return self.convert_page_link(match.page_id)
+            if (href := href_str).startswith("#"):
                 if settings.export.page_href == "wiki":
                     return f"[[#{text}]]"
                 return f"[{text}](#{github_heading_slug(href[1:])})"

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1200,3 +1200,103 @@ class TestWikiLinkDisambiguation:
         PageTitleRegistry.reset()
         assert "Shared%20Title.md" in result
         assert result.startswith("[Shared Title](")
+
+
+class TestAbsoluteUrlPageLinks:
+    """Absolute Confluence URLs in href must resolve to page links, not pass through."""
+
+    def _make_target_page(self, page_id: int, title: str, space_key: str) -> Page:
+        space = Space(
+            base_url="https://example.com",
+            key=space_key,
+            name=space_key,
+            description="",
+            homepage=0,
+        )
+        version = Version(
+            number=1,
+            by=User(
+                account_id="u1",
+                display_name="User",
+                username="user",
+                public_name="",
+                email="",
+            ),
+            when="2024-01-01T00:00:00Z",
+            friendly_when="Jan 1",
+        )
+        return Page(
+            base_url="https://example.com",
+            id=page_id,
+            title=title,
+            space=space,
+            ancestors=[],
+            version=version,
+            body="",
+            body_export="",
+            editor2="",
+            body_storage="",
+            labels=[],
+            attachments=[],
+        )
+
+    def test_absolute_url_same_host_resolves_page(self) -> None:
+        from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
+
+        PageTitleRegistry.reset()
+        target = self._make_target_page(1437663233, "Linked Page", "STRUCT")
+
+        source = _make_page(body="", body_export="", attachments=[])
+
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.Page.from_id",
+                return_value=target,
+            ),
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
+            s.export.page_href = "wiki"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            conv = Page.Converter(source)
+            html = (
+                '<a href="https://example.com/wiki/spaces/STRUCT/pages/1437663233">'
+                "https://example.com/wiki/spaces/STRUCT/pages/1437663233</a>"
+            )
+            result = conv.convert(html).strip()
+
+        PageTitleRegistry.reset()
+        assert result == "[[Linked Page]]"
+
+    def test_absolute_url_different_host_left_alone(self) -> None:
+        source = _make_page(body="", body_export="", attachments=[])
+        conv = Page.Converter(source)
+        html = (
+            '<a href="https://other.atlassian.net/wiki/spaces/X/pages/9/T">'
+            "https://other.atlassian.net/wiki/spaces/X/pages/9/T</a>"
+        )
+        result = conv.convert(html).strip()
+        assert result == "<https://other.atlassian.net/wiki/spaces/X/pages/9/T>"
+
+    def test_legacy_pageid_query_resolves_page(self) -> None:
+        from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
+
+        PageTitleRegistry.reset()
+        target = self._make_target_page(555, "Legacy Page", "OLD")
+
+        source = _make_page(body="", body_export="", attachments=[])
+
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.Page.from_id",
+                return_value=target,
+            ),
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
+            s.export.page_href = "wiki"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            conv = Page.Converter(source)
+            html = '<a href="https://example.com/pages/viewpage.action?pageId=555">x</a>'
+            result = conv.convert(html).strip()
+
+        PageTitleRegistry.reset()
+        assert result == "[[Legacy Page]]"


### PR DESCRIPTION
## Summary
- `convert_a` passed raw `href` to `parse_confluence_path`, which only matches path strings. Full URLs like `https://host/wiki/spaces/KEY/pages/123` (emitted by Confluence inline cards) fell through and rendered as bare autolinks instead of internal page links.
- Urlparse the href, gate on hostname match against `self.page.base_url` (so cross-instance URLs are not mis-resolved), then pass the path to `parse_confluence_path`.
- Also handle the `?pageId=` query parameter for legacy Server-style URLs, mirroring `Page.from_url`.

## Test plan
- [x] New test: same-host absolute URL resolves to wiki link
- [x] New test: cross-host absolute URL passes through unchanged
- [x] New test: legacy `?pageId=` query resolves to wiki link
- [x] Full unit suite: 356 passed
- [x] Re-exported failing page; previously bare `<https://.../pages/1437663233>` now renders as proper page link
