### PR TITLE
Support colored table cells

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -77,10 +77,32 @@ _MAX_UNICODE_CODEPOINT = 0x10FFFF
 _RE_RGB_BG = re.compile(r"background-color:\s*rgb\((\d+),\s*(\d+),\s*(\d+)\)")
 _RE_RGB_COLOR = re.compile(r"(?<![a-z-])color:\s*rgb\((\d+),\s*(\d+),\s*(\d+)\)")
 _RE_COLORID_CSS = re.compile(r"(?<![>\w])\[data-colorid=(\w+)\]\{color:(#[0-9a-fA-F]+)\}")
+_RE_HEX_COLOR = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+
+# Confluence default header backgrounds — applied automatically to <th> cells, and
+# (in matrix-style tables) to row-label <td>s. Treated as "no user-chosen colour".
+_DEFAULT_HEADER_BGS = frozenset({"#f4f5f7", "#f2f2f2"})
 
 
 def _rgb_to_hex(r: int, g: int, b: int) -> str:
     return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _extract_cell_highlight_hex(el: Tag) -> str | None:
+    """Return Confluence cell background hex from data-highlight-colour, or None.
+
+    Confluence Cloud sets `data-highlight-colour="#rrggbb"` (or `"transparent"`)
+    on `<td>` / `<th>` when a cell background colour is applied.
+    """
+    val = el.get("data-highlight-colour")
+    if not isinstance(val, str):
+        return None
+    val = val.strip().lower()
+    if not val or val == "transparent" or val in _DEFAULT_HEADER_BGS:
+        return None
+    if _RE_HEX_COLOR.match(val):
+        return val
+    return None
 
 
 # Background colours for Confluence status-badge lozenges (Atlassian design token pastels).
@@ -1526,6 +1548,23 @@ class Page(Document):
                 return None
             hex_color = _rgb_to_hex(int(bg_m.group(1)), int(bg_m.group(2)), int(bg_m.group(3)))
             return f'<mark style="background: {hex_color};">{text}</mark>'
+
+        def _wrap_cell_highlight(self, el: BeautifulSoup, text: str) -> str:
+            if not settings.export.convert_text_highlights:
+                return text
+            bg = _extract_cell_highlight_hex(el)
+            if bg is None:
+                return text
+            inner = text or "&nbsp;"
+            return f'<mark style="background: {bg};">{inner}</mark>'
+
+        def convert_td(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
+            text = super().convert_td(el, text, parent_tags)
+            return self._wrap_cell_highlight(el, text)
+
+        def convert_th(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
+            text = super().convert_th(el, text, parent_tags)
+            return self._wrap_cell_highlight(el, text)
 
         def _span_font_color(self, el: BeautifulSoup, style: str, text: str) -> str | None:
             color_m = _RE_RGB_COLOR.search(style)

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -622,6 +622,89 @@ class TestSpanHighlightConversion:
         assert "hello" in result
 
 
+class TestCellHighlightConversion:
+    """Confluence `data-highlight-colour` on <td>/<th> must become <mark> wrappers."""
+
+    def test_td_hex_attribute_wraps_in_mark(self, converter: Page.Converter) -> None:
+        html = (
+            '<table><tbody><tr>'
+            '<td data-highlight-colour="#fff0b3"><p>2</p></td>'
+            '</tr></tbody></table>'
+        )
+        result = converter.convert(html)
+        assert '<mark style="background: #fff0b3;">2</mark>' in result
+
+    def test_th_hex_attribute_wraps_in_mark(self, converter: Page.Converter) -> None:
+        html = (
+            '<table><tbody><tr>'
+            '<th data-highlight-colour="#ffd5d2"><p><strong>P / S</strong></p></th>'
+            '</tr></tbody></table>'
+        )
+        result = converter.convert(html)
+        assert '<mark style="background: #ffd5d2;">**P / S**</mark>' in result
+
+    def test_default_header_gray_not_wrapped(self, converter: Page.Converter) -> None:
+        """Confluence's default <th> background (#f4f5f7) is not user-chosen — skip."""
+        html = (
+            '<table><tbody><tr>'
+            '<th data-highlight-colour="#f4f5f7"><p><strong>P / S</strong></p></th>'
+            '<td data-highlight-colour="#f4f5f7"><p><strong>P5</strong></p></td>'
+            '</tr></tbody></table>'
+        )
+        result = converter.convert(html)
+        assert "<mark" not in result
+
+    def test_transparent_attribute_not_wrapped(self, converter: Page.Converter) -> None:
+        html = (
+            '<table><tbody><tr>'
+            '<td data-highlight-colour="transparent"><p>plain</p></td>'
+            '</tr></tbody></table>'
+        )
+        result = converter.convert(html)
+        assert "<mark" not in result
+        assert "plain" in result
+
+    def test_missing_attribute_not_wrapped(self, converter: Page.Converter) -> None:
+        html = (
+            '<table><tbody><tr><td><p>plain</p></td></tr></tbody></table>'
+        )
+        result = converter.convert(html)
+        assert "<mark" not in result
+        assert "plain" in result
+
+    def test_invalid_hex_not_wrapped(self, converter: Page.Converter) -> None:
+        html = (
+            '<table><tbody><tr>'
+            '<td data-highlight-colour="not-a-color"><p>x</p></td>'
+            '</tr></tbody></table>'
+        )
+        result = converter.convert(html)
+        assert "<mark" not in result
+
+    def test_empty_cell_with_highlight_renders_nbsp(self, converter: Page.Converter) -> None:
+        html = (
+            '<table><tbody><tr>'
+            '<td data-highlight-colour="#ff8f73"></td>'
+            '</tr></tbody></table>'
+        )
+        result = converter.convert(html)
+        assert '<mark style="background: #ff8f73;">&nbsp;</mark>' in result
+
+    def test_setting_disabled_returns_plain_text(self, converter: Page.Converter) -> None:
+        html = (
+            '<table><tbody><tr>'
+            '<td data-highlight-colour="#fff0b3"><p>2</p></td>'
+            '</tr></tbody></table>'
+        )
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.convert_text_highlights = False
+            s.export.convert_font_colors = True
+            s.export.convert_status_badges = True
+            result = converter.convert(html)
+        assert "<mark" not in result
+        assert "2" in result
+
+
 class TestSpanFontColorConversion:
     """Color spans must become <font> elements when enabled."""
 


### PR DESCRIPTION
## Summary

Confluence sets `data-highlight-colour="#hex"` on `<td>` / `<th>` cells when a cell background colour is applied (e.g. risk matrix traffic-light cells). The exporter previously dropped this signal, so colored matrices rendered as plain monochrome markdown tables — losing review-critical context for ISO 14971 / MDR documentation.

This PR passes Confluence cell background colours through to markdown by wrapping cell content in `<mark style="background: #hex;">…</mark>`, the same pattern already used for `<span>` background highlights and status-macro lozenges. Empty colored cells emit `&nbsp;` so the colour stays visible.

Confluence's default header greys (`#f4f5f7`, `#f2f2f2`) are filtered out — they're applied automatically to `<th>` and matrix row-label `<td>`s and aren't user-chosen colour.

Gated by the existing `export.convert_text_highlights` setting, so users can opt out alongside span highlights. `transparent` and missing/invalid attribute values fall through unchanged.

## Test Plan

- 8 new unit tests in `TestCellHighlightConversion` covering: hex passthrough on `<td>` and `<th>`, `transparent`, missing attribute, invalid hex, empty colored cell (`&nbsp;`), default header grey skip, and `convert_text_highlights=False` opt-out.
- Full suite green (367 passed).
- End-to-end on a real risk-matrix page (`body_view.html`): yellow `#fff0b3` and red `#ff8f73` cells render as `<mark>` wrappers, P/S header cells stay plain, lozenge `JA` badges still render via the existing `_span_status_badge` path.
