### PR TITLE
Isolate tests from developer's user config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,14 +17,14 @@ from unittest.mock import MagicMock
 _test_config_dir = tempfile.mkdtemp(prefix="cme-test-config-")
 os.environ["CME_CONFIG_PATH"] = str(Path(_test_config_dir) / "app_data.json")
 
-import pytest
-from pydantic import SecretStr
+import pytest  # noqa: E402
+from pydantic import SecretStr  # noqa: E402
 
-from confluence_markdown_exporter.utils.app_data_store import ApiDetails
-from confluence_markdown_exporter.utils.app_data_store import AuthConfig
-from confluence_markdown_exporter.utils.app_data_store import ConfigModel
-from confluence_markdown_exporter.utils.app_data_store import ConnectionConfig
-from confluence_markdown_exporter.utils.app_data_store import ExportConfig
+from confluence_markdown_exporter.utils.app_data_store import ApiDetails  # noqa: E402
+from confluence_markdown_exporter.utils.app_data_store import AuthConfig  # noqa: E402
+from confluence_markdown_exporter.utils.app_data_store import ConfigModel  # noqa: E402
+from confluence_markdown_exporter.utils.app_data_store import ConnectionConfig  # noqa: E402
+from confluence_markdown_exporter.utils.app_data_store import ExportConfig  # noqa: E402
 
 # Store original functions before any patching
 _original_get_confluence = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,21 @@
 """Shared test fixtures and configuration for confluence-markdown-exporter tests."""
 
 import importlib
+import os
 import sys
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
+
+# Isolate tests from the developer's user config. The package binds APP_CONFIG_PATH
+# at import time from CME_CONFIG_PATH (or, when unset, typer.get_app_dir() which
+# resolves to ~/.config/confluence-markdown-exporter/app_data.json on Linux).
+# Without this, local settings like `page_href="wiki"` leak into tests that rely
+# on the schema defaults.
+_test_config_dir = tempfile.mkdtemp(prefix="cme-test-config-")
+os.environ["CME_CONFIG_PATH"] = str(Path(_test_config_dir) / "app_data.json")
 
 import pytest
 from pydantic import SecretStr


### PR DESCRIPTION

## Summary

Three tests in `TestAnchorLinkConversion`
(`tests/unit/test_confluence.py`) fail on any developer machine that has
`export.page_href` set to `"wiki"` in
`~/.config/confluence-markdown-exporter/app_data.json` (the default
config location resolved via `typer.get_app_dir()` on Linux):

```
FAILED tests/unit/test_confluence.py::TestAnchorLinkConversion::test_anchor_uses_href_not_link_text
FAILED tests/unit/test_confluence.py::TestAnchorLinkConversion::test_anchor_plain_heading
FAILED tests/unit/test_confluence.py::TestAnchorLinkConversion::test_anchor_with_numbers_and_punctuation

E   AssertionError: assert '[[#My Heading]]' == '[My Heading](#my-heading)'
```

The tests assert markdown anchor output (`[text](#slug)`) but, because
they don't mock `settings.export.page_href`, they pick up whatever value
the developer has stored locally and emit Obsidian-style wikilinks
(`[[#text]]`) when the user prefers `wiki` href mode. The neighbouring
`test_wiki_anchor_uses_link_text` mocks the setting explicitly, so it is
unaffected; tests that don't read `page_href` at all are also unaffected.

## Root cause

`confluence_markdown_exporter.utils.app_data_store` binds
`APP_CONFIG_PATH` at module import time:

```python
# app_data_store.py
APP_CONFIG_PATH = get_app_config_path()
```

`get_app_config_path()` honours `CME_CONFIG_PATH` if set, otherwise it
falls back to `typer.get_app_dir("confluence-markdown-exporter")` —
i.e. the developer's real user config. The test suite has no isolation
layer for this, so any setting saved by a real run of the tool leaks
into the test process.

## Fix

Set `CME_CONFIG_PATH` to a path inside a fresh tmp dir at the very top
of `tests/conftest.py`, **before** `confluence_markdown_exporter` is
imported. The file does not exist, so `load_app_data()` falls back to
the Pydantic schema defaults (`page_href="relative"`, etc.), giving
every test run the same baseline regardless of host config.

```python
# tests/conftest.py
_test_config_dir = tempfile.mkdtemp(prefix="cme-test-config-")
os.environ["CME_CONFIG_PATH"] = str(Path(_test_config_dir) / "app_data.json")

import pytest
...
from confluence_markdown_exporter.utils.app_data_store import ApiDetails
```

The placement matters: `APP_CONFIG_PATH` is captured at import time, so
the env var must be set before the first `confluence_markdown_exporter`
import on the entire test process. Top-of-`conftest.py` is the earliest
hook available without registering a plugin.

## Alternative considered

A more local fix is to add a `with patch("…confluence.settings")`
block to each of the three failing tests (mirroring the existing
`test_wiki_anchor_uses_link_text` pattern) and explicitly set
`page_href="relative"`. That fixes the immediate failures with a
~12-line diff inside the test file and leaves the test infrastructure
untouched.

I went with the conftest-level fix because it addresses the underlying
cause — tests reading the developer's user config — once for the whole
suite, instead of patching one symptom at a time. Future tests that
indirectly depend on `settings` defaults won't silently start failing
on machines where someone exported with a non-default `page_href`,
`attachments_export`, `page_path`, etc. Happy to switch to the local
mock approach if reviewers prefer the smaller diff.

## Out of scope

- Test fixtures for the `settings` object itself (e.g. an autouse
  `mock_settings` fixture). The current per-test `with patch(...)`
  pattern is left in place; this PR only ensures the unmocked default
  path gives Pydantic defaults rather than the developer's config.
- Cleanup of the tmp dir at session end. It's a single empty directory
  per pytest run under `/tmp` and gets cleaned by the OS.

> Investigation and patch prepared by Claude Opus 4.7 from a hand-written
> brief; reviewed and verified locally before opening this PR.

## Test Plan

```bash
uv run pytest tests/ -q          # 360 passed (was: 357 passed, 3 failed
                                 #              on a machine with
                                 #              page_href="wiki" in user config)
```

Reproducer for the original failure (no source changes needed, just
revert this PR):

```bash
mkdir -p ~/.config/confluence-markdown-exporter
echo '{"export": {"page_href": "wiki"}}' \
  > ~/.config/confluence-markdown-exporter/app_data.json
uv run pytest tests/unit/test_confluence.py::TestAnchorLinkConversion -q
# 3 failed, 1 passed
```

After the fix, the same three tests pass regardless of the host config.

Manually checked:

- `XDG_CONFIG_HOME=/tmp/empty uv run pytest …` — green (was green
  before the fix too; equivalent isolation, but only when developers
  remember to set it).
- With `page_href="wiki"` in real user config — green (was red
  before the fix).
- Without any user config file — green (was green).