### PR TITLE
feat: add PlantUML support for Confluence Server/Data Center

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1338,11 +1338,9 @@ class Page(Document):
             )
         logger.debug("Fetching page id=%s from %s", page_id, base_url)
         expand = (
-            "body.view,body.export_view,body.editor2,metadata.labels,"
+            "body.view,body.export_view,body.editor2,body.storage,metadata.labels,"
             "metadata.properties,ancestors,version,history,history.createdBy"
         )
-        if settings.export.image_captions:
-            expand += ",body.storage"
         try:
             return cls.from_json(
                 _require_dict(
@@ -1446,6 +1444,8 @@ class Page(Document):
             self._colorid_map_cache: dict[str, str] | None = None
             self._image_captions_cache: dict[str, str] | None = None
             self._panel_icon_map_cache: dict[str, str] | None = None
+            self._plantuml_index: int = 0
+            self._storage_plantuml_macros_cache: list[Tag] | None = None
 
         @property
         def _colorid_map(self) -> dict[str, str]:
@@ -1460,6 +1460,22 @@ class Page(Document):
                             cache[color_id] = m.group(2)
                 self._colorid_map_cache = cache
             return self._colorid_map_cache
+
+        @property
+        def _storage_plantuml_macros(self) -> list[Tag]:
+            """Cache and return all PlantUML structured-macros from body.storage."""
+            if self._storage_plantuml_macros_cache is None:
+                macros: list[Tag] = []
+                if self.page.body_storage:
+                    wrapped = f"<root>{self.page.body_storage}</root>"
+                    soup = BeautifulSoup(wrapped, "xml")
+                    macros.extend(
+                        macro
+                        for macro in soup.find_all("structured-macro")
+                        if isinstance(macro, Tag) and macro.get("name") == "plantuml"
+                    )
+                self._storage_plantuml_macros_cache = macros
+            return self._storage_plantuml_macros_cache
 
         @property
         def _image_captions(self) -> dict[str, str]:
@@ -1788,7 +1804,7 @@ class Page(Document):
                     break
             return f'<mark style="background: {bg};">{text.strip()}</mark>'
 
-        def convert_span(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
+        def convert_span(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:  # noqa: C901, PLR0911
             if el.has_attr("data-macro-name"):
                 if el["data-macro-name"] == "jira":
                     return self.convert_jira_issue(el, text, parent_tags)
@@ -1796,6 +1812,8 @@ class Page(Document):
                     result = self._span_status_badge(el, text)
                     if result is not None:
                         return result
+                if el["data-macro-name"] == "plantuml":
+                    return self.convert_plantuml(el, text, parent_tags)
 
             if el.has_attr("class") and "inline-comment-marker" in el["class"]:
                 return self.convert_inline_comment_marker(el, text, parent_tags)
@@ -2354,67 +2372,73 @@ class Page(Document):
 
             return ""
 
-        def convert_plantuml(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:  # noqa: PLR0911, C901
-            """Convert PlantUML diagrams from editor2 XML to Markdown code blocks.
-
-            PlantUML diagrams are stored in the editor2 XML as structured macros with
-            the UML definition in a JSON structure inside CDATA sections.
-            """
-            # Parse the editor2 XML to find the PlantUML macro
-            # The editor2 content is an XML fragment without a root element, so wrap it
-            wrapped_editor2 = f"<root>{self.page.editor2}</root>"
-            soup_editor2 = BeautifulSoup(wrapped_editor2, "xml")
-
-            # Get the macro-id from the current element to match it in editor2
-            macro_id = el.get("data-macro-id")
-            if not macro_id:
-                logger.warning("PlantUML macro found but no macro-id attribute")
-                return "\n<!-- PlantUML diagram (no macro-id found) -->\n\n"
-
-            # Find the corresponding macro in editor2 XML
-            # BeautifulSoup with lxml strips namespace prefixes from both
-            # element and attribute names
-            # So ac:structured-macro becomes structured-macro, ac:name becomes name, etc.
-            plantuml_macros = soup_editor2.find_all("structured-macro")
-            plantuml_macro: Tag | None = None
-            for macro in plantuml_macros:
+        def _extract_uml_from_editor2(self, macro_id: str) -> str | None:
+            """Extract PlantUML source from editor2 XML by macro-id (Cloud format)."""
+            if not self.page.editor2:
+                return None
+            wrapped = f"<root>{self.page.editor2}</root>"
+            soup = BeautifulSoup(wrapped, "xml")
+            for macro in soup.find_all("structured-macro"):
                 if not isinstance(macro, Tag):
                     continue
-                if macro.get("name") == "plantuml" and macro.get("macro-id") == macro_id:
-                    plantuml_macro = macro
-                    break
+                if macro.get("name") != "plantuml" or macro.get("macro-id") != macro_id:
+                    continue
+                plain_text_body = macro.find("plain-text-body")
+                if not isinstance(plain_text_body, Tag):
+                    continue
+                cdata = plain_text_body.get_text(strip=True)
+                if not cdata:
+                    continue
+                try:
+                    return json.loads(cdata).get("umlDefinition") or None
+                except json.JSONDecodeError:
+                    return None
+            return None
 
-            if not plantuml_macro:
-                logger.warning(f"PlantUML macro with id {macro_id} not found in editor2 XML")
-                return "\n<!-- PlantUML diagram (not found in editor2) -->\n\n"
-
-            # Extract the plain-text-body containing the JSON
-            plain_text_body = plantuml_macro.find("plain-text-body")
+        def _extract_uml_from_storage(self) -> str | None:
+            """Extract PlantUML source from body.storage by position (Server format)."""
+            storage_macros = self._storage_plantuml_macros
+            idx = self._plantuml_index
+            self._plantuml_index += 1
+            if idx >= len(storage_macros):
+                return None
+            plain_text_body = storage_macros[idx].find("plain-text-body")
             if not isinstance(plain_text_body, Tag):
-                logger.warning(f"PlantUML macro {macro_id} has no plain-text-body")
-                return "\n<!-- PlantUML diagram (no content found) -->\n\n"
+                return None
+            uml = plain_text_body.get_text(strip=True)
+            return uml or None
 
-            # Extract the JSON from CDATA
-            cdata_content = plain_text_body.get_text(strip=True)
-            if not cdata_content:
-                logger.warning(f"PlantUML macro {macro_id} has empty content")
-                return "\n<!-- PlantUML diagram (empty content) -->\n\n"
+        def convert_plantuml(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
+            """Convert PlantUML diagrams to Markdown code blocks.
 
-            # Parse the JSON to get the umlDefinition
-            try:
-                plantuml_data = json.loads(cdata_content)
-                uml_definition = plantuml_data.get("umlDefinition", "")
+            Supports two Confluence formats:
 
-                if not uml_definition:
-                    logger.warning(f"PlantUML macro {macro_id} has no umlDefinition")
-                    return "\n<!-- PlantUML diagram (no UML definition) -->\n\n"
+            1. **Cloud / editor2**: The editor2 XML contains structured macros with
+               the UML definition in a JSON CDATA section (``{"umlDefinition": "..."}``).
+               Each macro carries a ``macro-id`` that is also present in the view
+               HTML as ``data-macro-id``.
 
-            except json.JSONDecodeError:
-                logger.exception(f"Failed to parse PlantUML JSON for macro {macro_id}")
-                return "\n<!-- PlantUML diagram (invalid JSON) -->\n\n"
-            else:
-                # Return as a Markdown code block with plantuml syntax
-                return f"\n```plantuml\n{uml_definition}\n```\n\n"
+            2. **Server / Data Center**: ``editor2`` is often empty.  The UML source
+               lives as raw ``@startuml`` text inside ``<plain-text-body>`` CDATA
+               sections in ``body.storage``.  The view HTML renders each diagram
+               inside a ``<span data-macro-name="plantuml">`` without a ``macro-id``.
+               Diagrams are matched by position (Nth diagram in storage corresponds
+               to the Nth ``<span>`` in view HTML).
+            """
+            # Strategy 1: editor2 with macro-id (Cloud)
+            macro_id = el.get("data-macro-id")
+            if macro_id:
+                uml = self._extract_uml_from_editor2(str(macro_id))
+                if uml:
+                    return f"\n```plantuml\n{uml}\n```\n\n"
+
+            # Strategy 2: body.storage fallback (Server / Data Center)
+            uml = self._extract_uml_from_storage()
+            if uml:
+                return f"\n```plantuml\n{uml}\n```\n\n"
+
+            logger.warning("PlantUML macro could not be resolved from editor2 or body.storage")
+            return "\n<!-- PlantUML diagram (source not found) -->\n\n"
 
         def convert_include(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
             """Convert Confluence `include` / `excerpt-include` macro.

--- a/tests/unit/test_plantuml_conversion.py
+++ b/tests/unit/test_plantuml_conversion.py
@@ -14,7 +14,7 @@ class TestPlantUMLConversion:
 
     @pytest.fixture
     def mock_page(self) -> MagicMock:
-        """Create a mock page with PlantUML content."""
+        """Create a mock page with PlantUML content in editor2 (Cloud format)."""
         page = MagicMock(spec=Page)
         page.id = 12345
         page.title = "Test Page"
@@ -22,6 +22,7 @@ class TestPlantUMLConversion:
         page.labels = []
         page.ancestors = []
         page.attachments = []
+        page.body_storage = ""
 
         # Sample editor2 XML with PlantUML macro
         uml_data = '{"umlDefinition":"@startuml\\nAlice -> Bob: Hello\\n@enduml"}'
@@ -34,51 +35,139 @@ class TestPlantUMLConversion:
 
         return page
 
-    @patch('confluence_markdown_exporter.confluence.settings')
-    def test_convert_plantuml_basic(
+    @pytest.fixture
+    def mock_server_page(self) -> MagicMock:
+        """Create a mock page with PlantUML content in body.storage (Server format)."""
+        page = MagicMock(spec=Page)
+        page.id = 67890
+        page.title = "Server Page"
+        page.html = "<h1>Server Page</h1>"
+        page.labels = []
+        page.ancestors = []
+        page.attachments = []
+        page.editor2 = ""
+
+        page.body_storage = (
+            '<ac:structured-macro ac:name="plantuml">'
+            "<ac:plain-text-body>"
+            "<![CDATA[@startuml\nAlice -> Bob: Hello\n@enduml]]>"
+            "</ac:plain-text-body>"
+            "</ac:structured-macro>"
+        )
+
+        return page
+
+    @patch("confluence_markdown_exporter.confluence.settings")
+    def test_convert_plantuml_cloud_editor2(
         self, mock_settings: MagicMock, mock_page: MagicMock
     ) -> None:
-        """Test basic PlantUML conversion to Markdown."""
+        """Test PlantUML conversion from editor2 XML (Cloud format)."""
         mock_settings.export.include_document_title = False
         mock_settings.export.page_breadcrumbs = False
 
-        # Create the converter
         converter = Page.Converter(mock_page)
 
-        # Create HTML element that represents PlantUML in the view
         html = '<div data-macro-name="plantuml" data-macro-id="test-macro-id-123"></div>'
-        el = BeautifulSoup(html, 'html.parser').find('div')
+        el = BeautifulSoup(html, "html.parser").find("div")
 
-        # Convert
         result = converter.convert_plantuml(el, "", [])
 
-        # Verify the output is a PlantUML code block
         assert "```plantuml" in result
         assert "@startuml" in result
         assert "Alice -> Bob: Hello" in result
         assert "@enduml" in result
-        assert "```" in result
 
-    @patch('confluence_markdown_exporter.confluence.settings')
-    def test_convert_plantuml_no_macro_id(
-        self, mock_settings: MagicMock, mock_page: MagicMock
+    @patch("confluence_markdown_exporter.confluence.settings")
+    def test_convert_plantuml_server_storage(
+        self, mock_settings: MagicMock, mock_server_page: MagicMock
     ) -> None:
-        """Test PlantUML conversion when macro-id is missing."""
+        """Test PlantUML conversion from body.storage (Server/DC format)."""
         mock_settings.export.include_document_title = False
 
-        converter = Page.Converter(mock_page)
+        converter = Page.Converter(mock_server_page)
 
-        # HTML element without macro-id
-        html = '<div data-macro-name="plantuml"></div>'
-        el = BeautifulSoup(html, 'html.parser').find('div')
+        # Server renders PlantUML as <span> without macro-id
+        html = '<span class="plantuml-svg-image" data-macro-name="plantuml"></span>'
+        el = BeautifulSoup(html, "html.parser").find("span")
 
         result = converter.convert_plantuml(el, "", [])
 
-        # Should return a comment
-        assert "<!-- PlantUML diagram" in result
-        assert "no macro-id found" in result
+        assert "```plantuml" in result
+        assert "@startuml" in result
+        assert "Alice -> Bob: Hello" in result
+        assert "@enduml" in result
 
-    @patch('confluence_markdown_exporter.confluence.settings')
+    @patch("confluence_markdown_exporter.confluence.settings")
+    def test_convert_plantuml_server_multiple_diagrams(
+        self, mock_settings: MagicMock
+    ) -> None:
+        """Test positional matching of multiple PlantUML diagrams on Server."""
+        mock_settings.export.include_document_title = False
+
+        page = MagicMock(spec=Page)
+        page.id = 11111
+        page.title = "Multi-Diagram Page"
+        page.html = "<h1>Multi-Diagram Page</h1>"
+        page.labels = []
+        page.ancestors = []
+        page.attachments = []
+        page.editor2 = ""
+
+        page.body_storage = (
+            '<ac:structured-macro ac:name="plantuml">'
+            "<ac:plain-text-body>"
+            "<![CDATA[@startuml\nAlice -> Bob: First\n@enduml]]>"
+            "</ac:plain-text-body>"
+            "</ac:structured-macro>"
+            "<p>Some text between diagrams</p>"
+            '<ac:structured-macro ac:name="plantuml">'
+            "<ac:plain-text-body>"
+            "<![CDATA[@startuml\nBob -> Carol: Second\n@enduml]]>"
+            "</ac:plain-text-body>"
+            "</ac:structured-macro>"
+        )
+
+        converter = Page.Converter(page)
+
+        html1 = '<span data-macro-name="plantuml"></span>'
+        el1 = BeautifulSoup(html1, "html.parser").find("span")
+        result1 = converter.convert_plantuml(el1, "", [])
+
+        html2 = '<span data-macro-name="plantuml"></span>'
+        el2 = BeautifulSoup(html2, "html.parser").find("span")
+        result2 = converter.convert_plantuml(el2, "", [])
+
+        assert "Alice -> Bob: First" in result1
+        assert "Bob -> Carol: Second" in result2
+
+    @patch("confluence_markdown_exporter.confluence.settings")
+    def test_convert_plantuml_no_source_available(
+        self, mock_settings: MagicMock
+    ) -> None:
+        """Test PlantUML conversion when neither editor2 nor storage has content."""
+        mock_settings.export.include_document_title = False
+
+        page = MagicMock(spec=Page)
+        page.id = 99999
+        page.title = "Empty Page"
+        page.html = "<h1>Empty Page</h1>"
+        page.labels = []
+        page.ancestors = []
+        page.attachments = []
+        page.editor2 = ""
+        page.body_storage = ""
+
+        converter = Page.Converter(page)
+
+        html = '<div data-macro-name="plantuml"></div>'
+        el = BeautifulSoup(html, "html.parser").find("div")
+
+        result = converter.convert_plantuml(el, "", [])
+
+        assert "<!-- PlantUML diagram" in result
+        assert "source not found" in result
+
+    @patch("confluence_markdown_exporter.confluence.settings")
     def test_convert_plantuml_complex_diagram(self, mock_settings: MagicMock) -> None:
         """Test PlantUML conversion with a complex diagram."""
         mock_settings.export.include_document_title = False
@@ -90,6 +179,7 @@ class TestPlantUMLConversion:
         page.labels = []
         page.ancestors = []
         page.attachments = []
+        page.body_storage = ""
 
         # Complex PlantUML diagram - properly escaped for JSON
         uml_definition = (
@@ -106,66 +196,116 @@ class TestPlantUMLConversion:
         converter = Page.Converter(page)
 
         html = '<div data-macro-name="plantuml" data-macro-id="complex-macro-id"></div>'
-        el = BeautifulSoup(html, 'html.parser').find('div')
+        el = BeautifulSoup(html, "html.parser").find("div")
 
         result = converter.convert_plantuml(el, "", [])
 
-        # Verify complex content is preserved
         assert "```plantuml" in result
         assert "@startuml" in result
         assert "skinparam backgroundColor white" in result
         assert "title Test Diagram" in result
         assert "@enduml" in result
 
-    @patch('confluence_markdown_exporter.confluence.settings')
-    def test_convert_plantuml_not_found_in_editor2(
-        self, mock_settings: MagicMock, mock_page: MagicMock
+    @patch("confluence_markdown_exporter.confluence.settings")
+    def test_convert_plantuml_editor2_fallback_to_storage(
+        self, mock_settings: MagicMock
     ) -> None:
-        """Test PlantUML conversion when macro not found in editor2."""
-        mock_settings.export.include_document_title = False
-
-        # Set editor2 with different macro-id
-        mock_page.editor2 = '''<?xml version="1.0" encoding="UTF-8"?>
-<ac:structured-macro ac:name="plantuml" ac:macro-id="different-id">
-    <ac:plain-text-body><![CDATA[{"umlDefinition":"test"}]]></ac:plain-text-body>
-</ac:structured-macro>'''
-
-        converter = Page.Converter(mock_page)
-
-        html = '<div data-macro-name="plantuml" data-macro-id="test-macro-id-123"></div>'
-        el = BeautifulSoup(html, 'html.parser').find('div')
-
-        result = converter.convert_plantuml(el, "", [])
-
-        assert "<!-- PlantUML diagram" in result
-        assert "not found in editor2" in result
-
-    @patch('confluence_markdown_exporter.confluence.settings')
-    def test_convert_plantuml_invalid_json(self, mock_settings: MagicMock) -> None:
-        """Test PlantUML conversion with invalid JSON."""
+        """Test that when editor2 macro-id doesn't match, storage is used as fallback."""
         mock_settings.export.include_document_title = False
 
         page = MagicMock(spec=Page)
-        page.id = 12345
-        page.title = "Test Page"
-        page.html = "<h1>Test Page</h1>"
+        page.id = 22222
+        page.title = "Fallback Page"
+        page.html = "<h1>Fallback Page</h1>"
         page.labels = []
         page.ancestors = []
         page.attachments = []
 
-        # Invalid JSON in CDATA
+        # editor2 has a macro but with a different ID
         page.editor2 = '''<?xml version="1.0" encoding="UTF-8"?>
-<ac:structured-macro ac:name="plantuml" ac:macro-id="invalid-json-id">
-    <ac:plain-text-body><![CDATA[{invalid json}]]></ac:plain-text-body>
+<ac:structured-macro ac:name="plantuml" ac:macro-id="different-id">
+    <ac:plain-text-body><![CDATA[{"umlDefinition":"@startuml\\nwrong\\n@enduml"}]]></ac:plain-text-body>
 </ac:structured-macro>'''
+
+        # body.storage has the correct content
+        page.body_storage = (
+            '<ac:structured-macro ac:name="plantuml">'
+            "<ac:plain-text-body>"
+            "<![CDATA[@startuml\nCorrect from storage\n@enduml]]>"
+            "</ac:plain-text-body>"
+            "</ac:structured-macro>"
+        )
 
         converter = Page.Converter(page)
 
-        html = '<div data-macro-name="plantuml" data-macro-id="invalid-json-id"></div>'
-        el = BeautifulSoup(html, 'html.parser').find('div')
+        # View element references an ID not found in editor2
+        html = '<div data-macro-name="plantuml" data-macro-id="nonexistent-id"></div>'
+        el = BeautifulSoup(html, "html.parser").find("div")
 
         result = converter.convert_plantuml(el, "", [])
 
-        assert "<!-- PlantUML diagram" in result
-        assert "invalid JSON" in result
+        assert "```plantuml" in result
+        assert "Correct from storage" in result
+
+    @patch("confluence_markdown_exporter.confluence.settings")
+    def test_convert_plantuml_invalid_json_falls_through(
+        self, mock_settings: MagicMock
+    ) -> None:
+        """Test that invalid JSON in editor2 falls through to storage."""
+        mock_settings.export.include_document_title = False
+
+        page = MagicMock(spec=Page)
+        page.id = 33333
+        page.title = "Invalid JSON Page"
+        page.html = "<h1>Invalid JSON Page</h1>"
+        page.labels = []
+        page.ancestors = []
+        page.attachments = []
+
+        page.editor2 = '''<?xml version="1.0" encoding="UTF-8"?>
+<ac:structured-macro ac:name="plantuml" ac:macro-id="json-error-id">
+    <ac:plain-text-body><![CDATA[{invalid json}]]></ac:plain-text-body>
+</ac:structured-macro>'''
+
+        page.body_storage = (
+            '<ac:structured-macro ac:name="plantuml">'
+            "<ac:plain-text-body>"
+            "<![CDATA[@startuml\nFallback content\n@enduml]]>"
+            "</ac:plain-text-body>"
+            "</ac:structured-macro>"
+        )
+
+        converter = Page.Converter(page)
+
+        html = '<div data-macro-name="plantuml" data-macro-id="json-error-id"></div>'
+        el = BeautifulSoup(html, "html.parser").find("div")
+
+        result = converter.convert_plantuml(el, "", [])
+
+        assert "```plantuml" in result
+        assert "Fallback content" in result
+
+    @patch("confluence_markdown_exporter.confluence.settings")
+    def test_convert_span_dispatches_plantuml(
+        self, mock_settings: MagicMock, mock_server_page: MagicMock
+    ) -> None:
+        """Test that convert_span dispatches plantuml macros on Server."""
+        mock_settings.export.include_document_title = False
+        mock_settings.export.convert_text_highlights = False
+        mock_settings.export.convert_font_colors = False
+
+        converter = Page.Converter(mock_server_page)
+
+        html = (
+            '<span class="plantuml-svg-image conf-macro output-inline" '
+            'data-hasbody="true" data-macro-name="plantuml">'
+            "<svg>...</svg>"
+            "</span>"
+        )
+        el = BeautifulSoup(html, "html.parser").find("span")
+
+        result = converter.convert_span(el, "svg text", [])
+
+        assert "```plantuml" in result
+        assert "@startuml" in result
 


### PR DESCRIPTION
## Summary

On Confluence Server and Data Center, `body.editor2` is often empty and PlantUML diagrams are stored as raw `@startuml`/`@enduml` source inside `body.storage` CDATA sections. The view HTML renders them as `<span data-macro-name="plantuml">` elements without a `data-macro-id`.

The existing `convert_plantuml` only supports the Cloud format (editor2 + macro-id matching), so Server/DC exports produce flattened SVG text or HTML comments instead of fenced PlantUML code blocks.

## Changes

- **Always include `body.storage`** in the REST API expand parameter (previously only included when `image_captions` was enabled)
- **Add `convert_span` dispatch** for `plantuml` macros — Server renders PlantUML inside `<span>` elements rather than `<div>`
- **Add body.storage fallback** in `convert_plantuml` using positional matching when editor2/macro-id is unavailable
- **Extract helper methods** `_extract_uml_from_editor2` and `_extract_uml_from_storage` for cleaner separation
- **Add `_storage_plantuml_macros`** cached property for parsing body.storage macros once per page

## How it works

1. **Cloud path (unchanged):** If `data-macro-id` is present, look up the matching macro in editor2 XML and parse the JSON `umlDefinition`.
2. **Server/DC path (new):** If editor2 lookup fails, fall back to positional matching — the Nth PlantUML element in `body.view` maps to the Nth `ac:structured-macro` in `body.storage`.

## Testing

- Updated existing PlantUML tests to cover both Cloud and Server formats
- Added tests for: Server storage extraction, multiple diagrams positional matching, editor2-to-storage fallback, invalid JSON fallback
- All 407 tests pass with `uv run pytest`
- All lint checks pass with `uv run ruff check`

## Real-world validation

Tested against a Confluence Server instance with 246 pages. 15 pages contained PlantUML diagrams that were previously exported as flattened SVG text — all now export correctly as fenced ```plantuml``` code blocks.