### PR TITLE
feat(logging): add export.save_log_to_file to also write logs to disk

### DIFF
--- a/confluence_markdown_exporter/config.py
+++ b/confluence_markdown_exporter/config.py
@@ -24,6 +24,7 @@ _CONFIG_KEYS_EPILOG = (
     "| --- | ----------- |\n\n"
     "| `export.output_path` | Directory where exported files are saved |\n\n"
     "| `export.log_level` | Verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |\n\n"
+    "| `export.save_log_to_file` | Also write logs to `cme.log` next to the config file |\n\n"
     "| `export.skip_unchanged` | Skip pages unchanged since last export |\n\n"
     "| `export.cleanup_stale` | Delete local files for removed pages |\n\n"
     "| `export.page_path` | File path template for exported pages |\n\n"

--- a/confluence_markdown_exporter/main.py
+++ b/confluence_markdown_exporter/main.py
@@ -13,6 +13,7 @@ from rich.table import Table
 
 from confluence_markdown_exporter import __version__
 from confluence_markdown_exporter import config as config_module
+from confluence_markdown_exporter.utils.app_data_store import APP_CONFIG_PATH
 from confluence_markdown_exporter.utils.app_data_store import get_settings
 from confluence_markdown_exporter.utils.lockfile import LockfileManager
 from confluence_markdown_exporter.utils.measure_time import measure
@@ -103,7 +104,9 @@ app.add_typer(config_module.app, name="config")
 
 def _init_logging() -> None:
     """Initialize logging from config (CME_EXPORT__LOG_LEVEL env var takes precedence)."""
-    setup_logging(get_settings().export.log_level)
+    export = get_settings().export
+    log_file = APP_CONFIG_PATH.parent / "cme.log" if export.save_log_to_file else None
+    setup_logging(export.log_level, log_file=log_file)
 
 
 def _print_summary() -> None:

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -311,6 +311,15 @@ class ExportConfig(BaseModel):
             "automatically."
         ),
     )
+    save_log_to_file: bool = Field(
+        default=False,
+        title="Save Log To File",
+        description=(
+            "Also write log records to a file alongside the console output. "
+            "The file is named 'cme.log' and lives next to the config file "
+            "(see 'cme config path'). Useful for capturing long DEBUG runs."
+        ),
+    )
     output_path: Path = Field(
         default=Path(),
         title="Output Path",

--- a/confluence_markdown_exporter/utils/rich_console.py
+++ b/confluence_markdown_exporter/utils/rich_console.py
@@ -5,6 +5,7 @@ import threading
 from dataclasses import dataclass
 from dataclasses import field
 from os import getenv
+from pathlib import Path
 
 from rich.console import Console
 from rich.logging import RichHandler
@@ -204,11 +205,14 @@ def get_rich_console(*, stderr: bool = False) -> Console:
 console: Console = get_rich_console()
 
 
-def setup_logging(log_level: str = "INFO") -> None:
+def setup_logging(log_level: str = "INFO", log_file: Path | None = None) -> None:
     """Configure the root logger to use rich output.
 
     Args:
         log_level: One of DEBUG, INFO, WARNING, ERROR.
+        log_file: Optional path to also write log records to. The file uses
+            a plain (non-rich) format so it is grep-friendly. Parent
+            directories are created if missing.
     """
     level = getattr(logging, log_level.upper(), logging.INFO)
     handler = RichHandler(
@@ -224,6 +228,14 @@ def setup_logging(log_level: str = "INFO") -> None:
     # Remove any existing handlers so we don't double-log
     root.handlers.clear()
     root.addHandler(handler)
+    if log_file is not None:
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(log_file, encoding="utf-8")
+        file_handler.setLevel(level)
+        file_handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+        )
+        root.addHandler(file_handler)
 
 
 @dataclass

--- a/tests/unit/utils/test_app_data_store_env.py
+++ b/tests/unit/utils/test_app_data_store_env.py
@@ -47,6 +47,16 @@ class TestEnvVarOverrides:
             settings = get_settings()
         assert settings.export.skip_unchanged is False
 
+    def test_save_log_to_file_default_false(self) -> None:
+        """save_log_to_file defaults to False so existing behavior is preserved."""
+        assert ExportConfig().save_log_to_file is False
+
+    def test_save_log_to_file_env_override(self) -> None:
+        """CME_EXPORT__SAVE_LOG_TO_FILE=true sets save_log_to_file to True."""
+        with patch.dict(os.environ, {"CME_EXPORT__SAVE_LOG_TO_FILE": "true"}):
+            settings = get_settings()
+        assert settings.export.save_log_to_file is True
+
     def test_attachments_export_env_override(self) -> None:
         """CME_EXPORT__ATTACHMENTS_EXPORT overrides attachments_export."""
         with patch.dict(os.environ, {"CME_EXPORT__ATTACHMENTS_EXPORT": "all"}):

--- a/tests/unit/utils/test_rich_console.py
+++ b/tests/unit/utils/test_rich_console.py
@@ -1,0 +1,33 @@
+"""Tests for the logging helpers in rich_console."""
+
+import logging
+from pathlib import Path
+
+from confluence_markdown_exporter.utils.rich_console import setup_logging
+
+
+def test_setup_logging_writes_to_file(tmp_path: Path) -> None:
+    """When a log_file is given, log records are also written to that file."""
+    log_file = tmp_path / "cme.log"
+    setup_logging("DEBUG", log_file=log_file)
+
+    logger = logging.getLogger("cme.test")
+    logger.debug("a debug message")
+    logger.info("an info message")
+
+    for handler in logging.getLogger().handlers:
+        handler.flush()
+
+    contents = log_file.read_text(encoding="utf-8")
+    assert "a debug message" in contents
+    assert "an info message" in contents
+
+
+def test_setup_logging_without_file_does_not_create_one(tmp_path: Path) -> None:
+    """Default invocation does not create a log file."""
+    log_file = tmp_path / "cme.log"
+    setup_logging("INFO")
+
+    logging.getLogger("cme.test").info("hello")
+
+    assert not log_file.exists()


### PR DESCRIPTION
## Summary

Adds a new `export.save_log_to_file` boolean setting that mirrors console log output to `cme.log` next to the config file (`cme config path`), as requested in #209 where the maintainer said "Happy to take a PR on this." Defaults to `false` so existing behavior is unchanged; flip it on for long DEBUG-level export runs that need the captured tail.

## Test Plan

- `uv run ruff check` clean on the touched files.
- `uv run pytest tests/` passes (408 tests), including two new ones in `test_rich_console.py` covering the file-writing path and the no-file default, plus default-value and env-override checks for the new field in `test_app_data_store_env.py`.
