### PR TITLE
fix(docker): cache deps separately from source to reuse layers across…

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -10,6 +10,18 @@ on:
       - pyproject.toml
       - uv.lock
       - confluence_markdown_exporter/**
+  # Also build on push to main so the GHA cache is primed on the default
+  # branch. Tag-triggered publish runs fall back to the default branch's
+  # cache, which would otherwise stay cold until the first release.
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - .github/workflows/docker-build.yml
+      - pyproject.toml
+      - uv.lock
+      - confluence_markdown_exporter/**
 
 permissions:
   contents: read

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,44 +5,35 @@ FROM python:3.12-slim AS builder
 
 ARG TARGETARCH
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    UV_LINK_MODE=copy \
+COPY --from=ghcr.io/astral-sh/uv:0.8 /uv /uvx /usr/local/bin/
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
     UV_PYTHON_DOWNLOADS=never
 
-# Keep apt archives in BuildKit caches so repeated builds skip the download.
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-$TARGETARCH \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-$TARGETARCH \
-    rm -f /etc/apt/apt.conf.d/docker-clean \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends build-essential
+WORKDIR /app
 
-COPY --from=ghcr.io/astral-sh/uv:0.8 /uv /usr/local/bin/uv
-
-WORKDIR /build
-
-# Resolve deps from the lockfile and emit requirements.txt for the runtime
-# stage. This layer is cached unless uv.lock / pyproject.toml change, which
-# decouples dependency installation from source-code edits.
-COPY pyproject.toml uv.lock README.md ./
+# Install runtime dependencies only. This layer is cached unless uv.lock or
+# pyproject.toml change. Metadata is bind-mounted so it does not get baked
+# into the layer and invalidate it on unrelated edits.
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-$TARGETARCH \
-    uv export --frozen --no-emit-project --no-dev --format requirements.txt \
-        -o /build/requirements.txt
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=README.md,target=README.md \
+    uv sync --locked --no-install-project --no-editable --no-dev
 
-# Build the project wheel. Only this layer needs to invalidate on source edits.
+# Install the project itself into the venv. Invalidates on source edits.
+COPY pyproject.toml uv.lock README.md ./
 COPY confluence_markdown_exporter ./confluence_markdown_exporter
 RUN --mount=type=cache,target=/root/.cache/uv,id=uv-$TARGETARCH \
-    uv build --no-sources
+    uv sync --locked --no-editable --no-dev
 
 # ---- runtime ---------------------------------------------------------------
 FROM python:3.12-slim AS runtime
 
-ARG TARGETARCH
-
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PATH="/app/.venv/bin:$PATH" \
     HOME=/data/config \
     XDG_CONFIG_HOME=/data/config \
     CME_CONFIG_PATH=/data/config/app_data.json \
@@ -53,19 +44,9 @@ RUN groupadd --system --gid 1000 cme \
     && mkdir -p /data/output /data/config \
     && chown -R cme:cme /data
 
-# Install runtime dependencies in a dedicated layer. This layer only
-# invalidates when the resolved requirements.txt changes (i.e. uv.lock /
-# pyproject.toml updates), not on every source edit.
-COPY --from=builder /build/requirements.txt /tmp/requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-$TARGETARCH \
-    pip install -r /tmp/requirements.txt \
-    && rm /tmp/requirements.txt
-
-# Install the project wheel without re-resolving deps. Fast, source-bound.
-COPY --from=builder /build/dist/*.whl /tmp/
-RUN --mount=type=cache,target=/root/.cache/pip,id=pip-$TARGETARCH \
-    pip install --no-deps /tmp/*.whl \
-    && rm /tmp/*.whl
+# Copy only the venv, not the source. `--no-editable` made the install
+# self-contained so the source tree is not needed at runtime.
+COPY --from=builder /app/.venv /app/.venv
 
 USER cme
 WORKDIR /data/output

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,33 +3,46 @@
 # ---- builder ---------------------------------------------------------------
 FROM python:3.12-slim AS builder
 
+ARG TARGETARCH
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIP_NO_CACHE_DIR=1 \
     UV_LINK_MODE=copy \
     UV_PYTHON_DOWNLOADS=never
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential \
-    && rm -rf /var/lib/apt/lists/*
+# Keep apt archives in BuildKit caches so repeated builds skip the download.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked,id=apt-cache-$TARGETARCH \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked,id=apt-lib-$TARGETARCH \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends build-essential
 
 COPY --from=ghcr.io/astral-sh/uv:0.8 /uv /usr/local/bin/uv
 
 WORKDIR /build
 
+# Resolve deps from the lockfile and emit requirements.txt for the runtime
+# stage. This layer is cached unless uv.lock / pyproject.toml change, which
+# decouples dependency installation from source-code edits.
 COPY pyproject.toml uv.lock README.md ./
-COPY confluence_markdown_exporter ./confluence_markdown_exporter
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-$TARGETARCH \
+    uv export --frozen --no-emit-project --no-dev --format requirements.txt \
+        -o /build/requirements.txt
 
-RUN uv build --no-sources
+# Build the project wheel. Only this layer needs to invalidate on source edits.
+COPY confluence_markdown_exporter ./confluence_markdown_exporter
+RUN --mount=type=cache,target=/root/.cache/uv,id=uv-$TARGETARCH \
+    uv build --no-sources
 
 # ---- runtime ---------------------------------------------------------------
 FROM python:3.12-slim AS runtime
 
+ARG TARGETARCH
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PIP_NO_CACHE_DIR=1 \
     HOME=/data/config \
     XDG_CONFIG_HOME=/data/config \
     CME_CONFIG_PATH=/data/config/app_data.json \
@@ -40,9 +53,18 @@ RUN groupadd --system --gid 1000 cme \
     && mkdir -p /data/output /data/config \
     && chown -R cme:cme /data
 
-COPY --from=builder /build/dist/*.whl /tmp/
+# Install runtime dependencies in a dedicated layer. This layer only
+# invalidates when the resolved requirements.txt changes (i.e. uv.lock /
+# pyproject.toml updates), not on every source edit.
+COPY --from=builder /build/requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-$TARGETARCH \
+    pip install -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
 
-RUN pip install --no-cache-dir /tmp/*.whl \
+# Install the project wheel without re-resolving deps. Fast, source-bound.
+COPY --from=builder /build/dist/*.whl /tmp/
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-$TARGETARCH \
+    pip install --no-deps /tmp/*.whl \
     && rm /tmp/*.whl
 
 USER cme


### PR DESCRIPTION
Restructure the build so that PR rebuilds and tag-based publishes do not re-download every transitive dependency on each commit. Previously the runtime stage installed the project wheel together with all its deps, so any source edit invalidated that layer and forced a fresh PyPI download of ~30 packages on each platform (~98s under arm64 emulation).

Changes:
- Builder emits a frozen requirements.txt via `uv export` (cached unless uv.lock/pyproject.toml change) and builds the project wheel separately.
- Runtime installs deps from requirements.txt first, then installs the project wheel with `--no-deps`. The deps layer survives source edits.
- Add BuildKit cache mounts for apt, uv and pip, keyed per \$TARGETARCH so amd64 and arm64 do not share caches.
- Drop PIP_NO_CACHE_DIR so the pip cache mount is actually populated.
- Run docker-build on push to main as well as on PRs. GHA cache writes are scoped per ref, and the tag-triggered publish workflow falls back to the default branch's cache; without a main-branch build the cache was cold on every release.

