### PR TITLE
docs: square favicon and navbar logo

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -6,7 +6,7 @@ const config: Config = {
   title: "Confluence Markdown Exporter",
   tagline:
     "Export Confluence pages to Markdown for Obsidian, Gollum, Azure DevOps, Foam, Dendron and more.",
-  favicon: "img/favicon.png",
+  favicon: "img/favicon.svg",
 
   url: "https://spenhouet.github.io",
   baseUrl: "/confluence-markdown-exporter/",
@@ -75,7 +75,7 @@ const config: Config = {
       title: "Confluence Markdown Exporter",
       logo: {
         alt: "confluence-markdown-exporter logo",
-        src: "img/logo.png",
+        src: "img/favicon.svg",
       },
       items: [
         {

--- a/static/img/favicon.svg
+++ b/static/img/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-label="confluence-markdown-exporter">
+  <rect width="200" height="200" rx="36" fill="#5b6cff"/>
+  <g fill="#fff" transform="translate(38 70) scale(0.85)">
+    <path d="M0 70V0h20l20 25L60 0h20v70H60V31L40 56 20 31v39z"/>
+    <path d="M125 70L95 37h20V0h20v37h20z"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- New square SVG favicon at `static/img/favicon.svg` — Markdown M↓ mark on a rounded primary-color square, original geometric paths (no Confluence trademark).
- `docusaurus.config.ts`: `favicon` and `navbar.logo.src` switched from PNG wordmark to the new SVG so it stays legible at 16–32px in browser tabs and the navbar.

## Test plan
- [x] `npm run build` succeeds.
- [ ] Verify favicon appears in browser tab and navbar after deploy.