### PR TITLE
Fix download attachment links

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2008,6 +2008,8 @@ class Page(Document):
                 # convert_attachment_link may return None if the attachment meta is incomplete
                 return link or f"[{text}]({el.get('href')})"
             href_str = str(el.get("href", ""))
+            if href_str and (attachment := self._attachment_from_download_href(href_str)):
+                return self._format_attachment_link(attachment)
             if href_str:
                 parsed_href = urlparse(href_str)
                 base_host = urlparse(getattr(self.page, "base_url", "") or "").hostname
@@ -2058,6 +2060,24 @@ class Page(Document):
             page_path = self._get_path_for_href(page.export_path, settings.export.page_href)
             return f"[{page.title}]({page_path.replace(' ', '%20')})"
 
+        def _format_attachment_link(self, attachment: Attachment) -> str:
+            if settings.export.attachment_href == "wiki":
+                return f"[[{attachment.export_path.name}|{attachment.title}]]"
+
+            path = self._get_path_for_href(attachment.export_path, settings.export.attachment_href)
+            return f"[{attachment.title}]({path.replace(' ', '%20')})"
+
+        def _attachment_from_download_href(self, href: str) -> Attachment | None:
+            parsed = urlparse(href)
+            path_parts = [unquote(part) for part in parsed.path.split("/") if part]
+            try:
+                filename = path_parts[path_parts.index("attachments") + 2]
+            except (ValueError, IndexError):
+                return None
+
+            matches = self.page.get_attachments_by_title(filename)
+            return matches[0] if matches else None
+
         def convert_attachment_link(
             self, el: BeautifulSoup, text: str, parent_tags: list[str]
         ) -> str:
@@ -2073,16 +2093,14 @@ class Page(Document):
                 attachment = self.page.get_attachment_by_file_id(str(fid))
             if not attachment and (aid := el.get("data-linked-resource-id")):
                 attachment = self.page.get_attachment_by_id(str(aid))
+            if not attachment and (href := el.get("href")):
+                attachment = self._attachment_from_download_href(str(href))
 
             if attachment is None:
                 href = el.get("href") or text
                 return f"[{text}]({href})"
 
-            if settings.export.attachment_href == "wiki":
-                return f"[[{attachment.export_path.name}|{attachment.title}]]"
-
-            path = self._get_path_for_href(attachment.export_path, settings.export.attachment_href)
-            return f"[{attachment.title}]({path.replace(' ', '%20')})"
+            return self._format_attachment_link(attachment)
 
         def convert_time(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
             if el.has_attr("datetime"):

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -175,6 +175,39 @@ def _make_page(
     )
 
 
+class TestAttachmentLinkConversion:
+    """Plain Confluence download links should resolve to exported attachment paths."""
+
+    def test_video_download_link_uses_exported_attachment_path(self) -> None:
+        att = _make_attachment(
+            "88888",
+            "f5a14888-2775-4394-b5a4-ac0ffc0c39f5",
+            title="Video Agenzia Entrate (2).mp4",
+            media_type="video/mp4",
+        )
+        page = _make_page(body="", body_export="", attachments=[att])
+        html = (
+            '<a href="/wiki/download/attachments/347766919/'
+            'Video%20Agenzia%20Entrate%20(2).mp4?version=3&api=v2&width=760">'
+            "Video Agenzia Entrate (2).mp4</a>"
+        )
+
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.attachment_href = "relative"
+            s.export.attachment_path = (
+                "{space_name}/attachments/{attachment_file_id}{attachment_extension}"
+            )
+            s.export.page_href = "relative"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            conv = Page.Converter(page)
+            result = conv.convert(html).strip()
+
+        assert result == (
+            "[Video Agenzia Entrate (2).mp4]"
+            "(attachments/f5a14888-2775-4394-b5a4-ac0ffc0c39f5.mp4)"
+        )
+
+
 class TestAttachmentsForExport:
     """_attachments_for_export selects the right attachments."""
 


### PR DESCRIPTION
## Summary

- resolve plain Confluence `/download/attachments/.../filename` links to the exported attachment path
- share the same attachment-link formatter between data-attribute links and download URL links
- add a regression test for the MP4 shape from #255

Closes #255.

## Tests

- `uv run pytest tests/unit/test_confluence.py -q`
- `uv run ruff check confluence_markdown_exporter/confluence.py tests/unit/test_confluence.py`
- `git diff --check`
