### PR TITLE
feat: add SSO cookie authentication

### DIFF
--- a/confluence_markdown_exporter/api_clients.py
+++ b/confluence_markdown_exporter/api_clients.py
@@ -189,7 +189,27 @@ class ApiClientFactory:
         )
 
     def create_confluence(self, url: str, auth: ApiDetails) -> ConfluenceApiSdk:
-        try:
+        # Check if session cookies are provided for SSO authentication
+        cookies_str = auth.session_cookies.get_secret_value() if auth.session_cookies else ""
+
+        if cookies_str:
+            # Create a custom session with cookies for SSO authentication
+            session = requests.Session()
+            cookies_dict = {}
+            for raw_cookie_pair in cookies_str.split(";"):
+                cookie_pair = raw_cookie_pair.strip()
+                if "=" in cookie_pair:
+                    name, value = cookie_pair.split("=", 1)
+                    cookies_dict[name.strip()] = value.strip()
+            session.cookies.update(cookies_dict)
+
+            instance = ConfluenceApiSdk(
+                url=url,
+                session=session,
+                **self.connection_config.model_dump(),
+            )
+        else:
+            # Standard authentication
             instance = ConfluenceApiSdk(
                 url=url,
                 username=auth.username.get_secret_value() if auth.api_token else None,
@@ -197,6 +217,8 @@ class ApiClientFactory:
                 token=auth.pat.get_secret_value() if auth.pat else None,
                 **self.connection_config.model_dump(),
             )
+
+        try:
             instance.get_all_spaces(limit=1)
         except Exception as e:
             msg = f"Confluence connection failed: {e}"

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -142,6 +142,15 @@ class ApiDetails(BaseModel):
             "See your Atlassian instance documentation for how to create a PAT."
         ),
     )
+    session_cookies: SecretStr = Field(
+        default=SecretStr(""),
+        title="Session Cookies",
+        description=(
+            "Session cookies for SSO authentication (e.g. from browser). "
+            "Format: cookie1=value1; cookie2=value2. "
+            "Use this when PAT is not available and you need to use browser session."
+        ),
+    )
     cloud_id: str = Field(
         default="",
         title="Cloud ID",
@@ -155,7 +164,7 @@ class ApiDetails(BaseModel):
         ),
     )
 
-    @field_validator("username", "api_token", "pat", mode="before")
+    @field_validator("username", "api_token", "pat", "session_cookies", mode="before")
     @classmethod
     def _single_line(cls, v: object) -> object:
         raw = v.get_secret_value() if isinstance(v, SecretStr) else v
@@ -163,7 +172,7 @@ class ApiDetails(BaseModel):
             return raw.replace("\r", "").replace("\n", "")
         return v
 
-    @field_serializer("username", "api_token", "pat", when_used="json")
+    @field_serializer("username", "api_token", "pat", "session_cookies", when_used="json")
     def dump_secret(self, v: SecretStr) -> str:
         return v.get_secret_value()
 

--- a/tests/unit/test_api_clients.py
+++ b/tests/unit/test_api_clients.py
@@ -219,6 +219,34 @@ class TestApiClientFactory:
         with pytest.raises(ConnectionError, match="Confluence connection failed"):
             factory.create_confluence(SAMPLE_CONFLUENCE_URL, sample_api_details)
 
+    @patch("confluence_markdown_exporter.api_clients.requests.Session")
+    @patch("confluence_markdown_exporter.api_clients.ConfluenceApiSdk")
+    def test_create_confluence_with_session_cookies_success(
+        self, mock_confluence_sdk: MagicMock, mock_session_class: MagicMock
+    ) -> None:
+        """Test successful Confluence client creation using session cookies."""
+        mock_instance = MagicMock()
+        mock_instance.get_all_spaces.return_value = [{"key": "TEST"}]
+        mock_confluence_sdk.return_value = mock_instance
+
+        mock_session = MagicMock()
+        mock_session_class.return_value = mock_session
+
+        sdk_config = AtlassianSdkConnectionConfig()
+        factory = ApiClientFactory(sdk_config)
+
+        auth_details = ApiDetails(session_cookies=SecretStr("sid=12345; foo=bar"))
+
+        result = factory.create_confluence(SAMPLE_CONFLUENCE_URL, auth_details)
+
+        assert result == mock_instance
+        mock_session.cookies.update.assert_called_once_with({"sid": "12345", "foo": "bar"})
+        mock_confluence_sdk.assert_called_once_with(
+            url=SAMPLE_CONFLUENCE_URL,
+            session=mock_session,
+            **sdk_config.model_dump(),
+        )
+
     @patch("confluence_markdown_exporter.api_clients.JiraApiSdk")
     def test_create_jira_success(
         self, mock_jira_sdk: MagicMock, sample_api_details: ApiDetails


### PR DESCRIPTION
Many internally deployed Confluence instances rely on SSO/session login, where API token authentication is not always available. This PR adds SSO cookie authentication support for the Confluence API client, extracted and cleaned up from #233 as requested by the maintainer.