### PR TITLE
feat: implement table_column_width option with aligned, compact, and mixed modes

### DIFF
--- a/confluence_markdown_exporter/config.py
+++ b/confluence_markdown_exporter/config.py
@@ -36,6 +36,8 @@ _CONFIG_KEYS_EPILOG = (
     "| `export.include_macro` | How to render `include`/`excerpt-include` macros:"
     " `inline` (default) or `transclusion` (Obsidian `![[Page Title]]` embed) |\n\n"
     "| `export.page_breadcrumbs` | Include breadcrumb links at top of page |\n\n"
+    "| `export.table_column_width` | Visual alignment of table columns: "
+    "`aligned`, `mixed` (default), or `compact` |\n\n"
     "| `export.confluence_url_in_frontmatter` | Include Confluence page URL in YAML "
     "front matter: `none`, `webui`, `tinyui`, `both` |\n\n"
     "| `export.page_metadata_in_frontmatter` | Add Confluence page metadata "
@@ -207,8 +209,7 @@ def list_config(
         "- `cme config get export.output_path`\n\n"
         "- `cme config get connection_config.max_workers`\n\n"
         "- `cme config get connection_config` — prints the whole section as YAML\n\n"
-        "- `cme config get export` — prints all export settings\n\n"
-        + _CONFIG_KEYS_EPILOG
+        "- `cme config get export` — prints all export settings\n\n" + _CONFIG_KEYS_EPILOG
     ),
 )
 def get(
@@ -256,8 +257,7 @@ def get(
         "- `cme config set connection_config.max_workers=5`\n\n"
         "- `cme config set connection_config.verify_ssl=false`\n\n"
         "- `cme config set export.log_level=INFO export.output_path=./out`"
-        " — multiple keys at once\n\n"
-        + _CONFIG_KEYS_EPILOG
+        " — multiple keys at once\n\n" + _CONFIG_KEYS_EPILOG
     ),
 )
 def set_config(

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -67,8 +67,8 @@ from confluence_markdown_exporter.utils.rich_console import ExportStats
 from confluence_markdown_exporter.utils.rich_console import console
 from confluence_markdown_exporter.utils.rich_console import get_stats
 from confluence_markdown_exporter.utils.rich_console import reset_stats
-from confluence_markdown_exporter.utils.table_converter import TableConverter
 from confluence_markdown_exporter.utils.table_converter import _MAX_TABLE_LINE_LEN
+from confluence_markdown_exporter.utils.table_converter import TableConverter
 from confluence_markdown_exporter.utils.table_converter import normalize_table_cell_text
 from confluence_markdown_exporter.utils.table_converter import to_markdown_table
 

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -68,6 +68,9 @@ from confluence_markdown_exporter.utils.rich_console import console
 from confluence_markdown_exporter.utils.rich_console import get_stats
 from confluence_markdown_exporter.utils.rich_console import reset_stats
 from confluence_markdown_exporter.utils.table_converter import TableConverter
+from confluence_markdown_exporter.utils.table_converter import _MAX_TABLE_LINE_LEN
+from confluence_markdown_exporter.utils.table_converter import normalize_table_cell_text
+from confluence_markdown_exporter.utils.table_converter import to_markdown_table
 
 JsonResponse: TypeAlias = dict
 StrPath: TypeAlias = str | PathLike[str]
@@ -87,6 +90,32 @@ _DEFAULT_HEADER_BGS = frozenset({"#f4f5f7", "#f2f2f2"})
 
 def _rgb_to_hex(r: int, g: int, b: int) -> str:
     return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _render_meta_bind_view_fields(props: dict[str, str], mode: str) -> str:
+    """Render metadata as Meta Bind VIEW fields in a two-column markdown table."""
+    table_data = [
+        [f"**{k}**", f"`VIEW[{{{sanitize_key(k)}}}][text(renderMarkdown)]`"] for k in props
+    ]
+    headers = ["", ""]
+
+    if mode == "compact":
+        rendered = to_markdown_table(table_data, headers=headers, escape_cells=True)
+    elif mode == "aligned":
+        # Escape pipe characters before passing to tabulate
+        escaped_data = [[normalize_table_cell_text(cell) for cell in row] for row in table_data]
+        rendered = tabulate(escaped_data, headers=headers, tablefmt="pipe")
+    else:
+        # mixed mode (default)
+        # Escape pipe characters before passing to tabulate
+        escaped_data = [[normalize_table_cell_text(cell) for cell in row] for row in table_data]
+        aligned = tabulate(escaped_data, headers=headers, tablefmt="pipe")
+        max_line_len = max(len(line) for line in aligned.splitlines()) if aligned else 0
+        if max_line_len > _MAX_TABLE_LINE_LEN:
+            rendered = to_markdown_table(table_data, headers=headers, escape_cells=True)
+        else:
+            rendered = aligned
+    return f"\n{rendered}\n"
 
 
 def _extract_cell_highlight_hex(el: Tag) -> str | None:
@@ -1007,7 +1036,6 @@ class Page(Document):
         )
         self._marked_texts: dict[str, str] = conv._marked_texts
 
-
     _COMMENT_TITLE_MAX_LEN = 60
 
     def _fetch_inline_comments(self) -> list[dict]:
@@ -1653,10 +1681,9 @@ class Page(Document):
                 return f"\n{lines}\n"
 
             # meta-bind-view-fields: two-column table with VIEW fields in value column
-            table_data = [
-                (f"**{k}**", f"`VIEW[{{{sanitize_key(k)}}}][text(renderMarkdown)]`") for k in props
-            ]
-            return "\n\n" + tabulate(table_data, headers=["", ""], tablefmt="pipe") + "\n"
+            mode = settings.export.table_column_width
+            rendered = _render_meta_bind_view_fields(props, mode)
+            return f"\n{rendered}"
 
         def convert_alert(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
             """Convert Confluence info macros to Markdown GitHub style alerts.
@@ -2694,7 +2721,7 @@ class Page(Document):
 
             parent_match = re.search(r'parent\s*=\s*"?(\d+)"?', cql, re.IGNORECASE)
             current_content_match = re.search(
-                r'(?:ancestor|parent)\s*=\s*currentContent\s*\(\s*\)', cql, re.IGNORECASE
+                r"(?:ancestor|parent)\s*=\s*currentContent\s*\(\s*\)", cql, re.IGNORECASE
             )
 
             from_clause: str | None = None

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -411,11 +411,7 @@ class ExportConfig(BaseModel):
         Templates that relied on that (i.e. no explicit {attachment_extension})
         are silently updated so file extensions are preserved.
         """
-        if (
-            isinstance(v, str)
-            and "{attachment_title}" in v
-            and "{attachment_extension}" not in v
-        ):
+        if isinstance(v, str) and "{attachment_title}" in v and "{attachment_extension}" not in v:
             return v.replace("{attachment_title}", "{attachment_title}{attachment_extension}")
         return v
 
@@ -448,6 +444,17 @@ class ExportConfig(BaseModel):
         default=True,
         title="Page Breadcrumbs",
         description="Whether to include breadcrumb links at the top of the page.",
+    )
+    table_column_width: Literal["aligned", "mixed", "compact"] = Field(
+        default="mixed",
+        title="Table Column Width Formatting",
+        description=(
+            "Controls the visual alignment of Markdown table columns.\n"
+            "  aligned: always align columns with space padding.\n"
+            "  mixed: auto-detect and keep simple tables aligned, but automatically format\n"
+            "    nested or extremely wide tables compactly to avoid space bloat (default).\n"
+            "  compact: never align columns, yielding minimal and clean markdown code."
+        ),
     )
     page_properties_format: Literal[
         "frontmatter",
@@ -543,9 +550,7 @@ class ExportConfig(BaseModel):
             return data
         old_val = data.pop("inline_comments", None)
         if old_val is not None and "comments_export" not in data:
-            data["comments_export"] = (
-                "inline" if str(old_val).lower() in ("true", "1") else "none"
-            )
+            data["comments_export"] = "inline" if str(old_val).lower() in ("true", "1") else "none"
         return data
 
     filename_encoding: str = Field(
@@ -632,7 +637,7 @@ class ExportConfig(BaseModel):
         title="Convert Status Badges",
         description=(
             "Whether to convert Confluence status badge macros "
-            "(<span class=\"status-macro ...\"/>) "
+            '(<span class="status-macro ..."/>) '
             "to HTML <mark> elements coloured with the badge's background colour. "
             "When disabled, only the badge label text is kept."
         ),
@@ -642,7 +647,7 @@ class ExportConfig(BaseModel):
         title="Convert Text Highlights",
         description=(
             "Whether to convert Confluence text highlights "
-            "(<span style=\"background-color: rgb(...);\"/>) "
+            '(<span style="background-color: rgb(...);"/>) '
             "to HTML <mark> elements with a hex color. "
             "When disabled, the highlight span is stripped and only the text is kept."
         ),
@@ -652,7 +657,7 @@ class ExportConfig(BaseModel):
         title="Convert Font Colors",
         description=(
             "Whether to convert Confluence font colors "
-            "(<span data-colorid=\"...\"/> or <span style=\"color: rgb(...);\"/>) "
+            '(<span data-colorid="..."/> or <span style="color: rgb(...);"/>) '
             "to HTML <font> elements with a hex color. "
             "When disabled, the color span is stripped and only the text is kept."
         ),

--- a/confluence_markdown_exporter/utils/table_converter.py
+++ b/confluence_markdown_exporter/utils/table_converter.py
@@ -6,8 +6,52 @@ from bs4 import Tag
 from markdownify import MarkdownConverter
 from tabulate import tabulate
 
+from confluence_markdown_exporter.utils.app_data_store import get_settings
+
+_MAX_TABLE_LINE_LEN = 120
+
 _LEADING_BR_OR_WS = re.compile(r"^(?:\s|<br\s*/?>)+")
 _TRAILING_BR_OR_WS = re.compile(r"(?:\s|<br\s*/?>)+$")
+
+
+def to_markdown_table(
+    rows: list[list[str]],
+    headers: list[str],
+    *,
+    escape_cells: bool = False,
+) -> str:
+    """Format a list of rows and headers as a compact GFM pipe table."""
+    if not headers and not rows:
+        return ""
+    col_count = len(headers) if headers else (len(rows[0]) if rows else 0)
+    if col_count == 0:
+        return ""
+
+    # Normalize headers to match col_count
+    actual_headers = list(headers) if headers else [""] * col_count
+    if len(actual_headers) < col_count:
+        actual_headers.extend([""] * (col_count - len(actual_headers)))
+    elif len(actual_headers) > col_count:
+        actual_headers = actual_headers[:col_count]
+
+    normalized_headers = (
+        [normalize_table_cell_text(str(cell)) for cell in actual_headers]
+        if escape_cells
+        else [str(cell) for cell in actual_headers]
+    )
+    lines = []
+    lines.append("| " + " | ".join(normalized_headers) + " |")
+    lines.append("| " + " | ".join(["---"] * col_count) + " |")
+    for row in rows:
+        actual_row = [str(cell) for cell in row]
+        if escape_cells:
+            actual_row = [normalize_table_cell_text(cell) for cell in actual_row]
+        if len(actual_row) < col_count:
+            actual_row.extend([""] * (col_count - len(actual_row)))
+        elif len(actual_row) > col_count:
+            actual_row = actual_row[:col_count]
+        lines.append("| " + " | ".join(actual_row) + " |")
+    return "\n".join(lines)
 
 
 def _get_int_attr(cell: Tag, attr: str, default: str = "1") -> int:
@@ -57,7 +101,7 @@ def make_empty_cell() -> Tag:
     return Tag(name="td")
 
 
-def _normalize_table_cell_text(text: str) -> str:
+def normalize_table_cell_text(text: str) -> str:
     text = text.replace("|", "\\|").replace("\n", "<br/>")
     text = _LEADING_BR_OR_WS.sub("", text)
     return _TRAILING_BR_OR_WS.sub("", text)
@@ -65,6 +109,38 @@ def _normalize_table_cell_text(text: str) -> str:
 
 class TableConverter(MarkdownConverter):
     """Custom MarkdownConverter for converting HTML tables to markdown tables."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self._table_column_width = kwargs.pop("table_column_width", None)
+        super().__init__(*args, **kwargs)
+
+    def _format_table(
+        self,
+        converted: list[list[str]],
+        *,
+        has_header: bool,
+        is_nested: bool,
+        mode: str,
+    ) -> str:
+        rows = converted[1:] if has_header else converted
+        headers = converted[0] if has_header else [""] * len(converted[0])
+
+        if mode == "compact":
+            return to_markdown_table(rows, headers=headers)
+
+        if mode == "aligned":
+            return tabulate(rows, headers=headers, tablefmt="pipe")
+
+        # mode == "mixed"
+        if is_nested:
+            return to_markdown_table(rows, headers=headers)
+
+        aligned = tabulate(rows, headers=headers, tablefmt="pipe")
+        max_line_len = max(len(line) for line in aligned.splitlines()) if aligned else 0
+        if max_line_len > _MAX_TABLE_LINE_LEN:
+            return to_markdown_table(rows, headers=headers)
+
+        return aligned
 
     def convert_table(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
         if "table" in parent_tags:
@@ -77,29 +153,38 @@ class TableConverter(MarkdownConverter):
             else:
                 row_tags.extend(cast("list[Tag]", child.find_all("tr", recursive=False)))
         rows = [
-            cast("list[Tag]", tr.find_all(["td", "th"], recursive=False))
-            for tr in row_tags
-            if tr
+            cast("list[Tag]", tr.find_all(["td", "th"], recursive=False)) for tr in row_tags if tr
         ]
 
-        if not rows:
+        # Check if rows is empty OR if all rows are empty lists (e.g., <tr></tr>)
+        if not rows or not any(rows):
             return ""
 
         padded_rows = pad(rows)
         converted = [
-            [self.process_tag(cell, parent_tags={"table"}) for cell in row]
-            for row in padded_rows
+            [self.process_tag(cell, parent_tags={"table"}) for cell in row] for row in padded_rows
         ]
 
         has_header = all(cell.name == "th" for cell in rows[0])
-        if has_header:
-            return tabulate(converted[1:], headers=converted[0], tablefmt="pipe")
 
-        return tabulate(converted, headers=[""] * len(converted[0]), tablefmt="pipe")
+        mode = self._table_column_width
+        if mode is None:
+            try:
+                mode = get_settings().export.table_column_width
+            except (AttributeError, RuntimeError):
+                mode = "mixed"
+
+        is_nested = any(cell.find("table") is not None for row in padded_rows for cell in row)
+        return self._format_table(
+            converted,
+            has_header=has_header,
+            is_nested=is_nested,
+            mode=mode,
+        )
 
     def convert_th(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
         """This method is empty because we want a No-Op for the <th> tag."""
-        return _normalize_table_cell_text(text)
+        return normalize_table_cell_text(text)
 
     def convert_tr(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
         """This method is empty because we want a No-Op for the <tr> tag."""
@@ -107,7 +192,7 @@ class TableConverter(MarkdownConverter):
 
     def convert_td(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
         """This method is empty because we want a No-Op for the <td> tag."""
-        return _normalize_table_cell_text(text)
+        return normalize_table_cell_text(text)
 
     def convert_thead(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
         """This method is empty because we want a No-Op for the <thead> tag."""

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -101,6 +101,19 @@ Whether to include breadcrumb links at the top of the page.
 - Default: `True`
 - ENV Var: `CME_EXPORT__PAGE_BREADCRUMBS`
 
+### export.table_column_width
+
+Controls the visual alignment and space padding of Markdown table columns.
+
+| Value | Behaviour |
+| ----- | --------- |
+| `aligned` | Always align table columns using spaces (legacy behavior). |
+| `mixed` | Smart hybrid mode: keeps simple tables aligned, but automatically formats nested or extremely wide tables compactly (default). |
+| `compact` | Never align column widths, outputting clean, tight, GFM-compliant pipe tables. |
+
+- Default: `mixed`
+- ENV Var: `CME_EXPORT__TABLE_COLUMN_WIDTH`
+
 ### export.page_properties_format
 
 Controls how Confluence Page Properties macros (key-value tables) are rendered. Duplicate property keys are automatically disambiguated by appending a counter (e.g. `status`, `status_2`, `status_3`).

--- a/tests/unit/utils/test_table_converter.py
+++ b/tests/unit/utils/test_table_converter.py
@@ -251,3 +251,65 @@ class TestTableConverter:
         assert el is not None
         result = converter.convert_p(el, "text.", {"td", "_inline"})  # type: ignore[arg-type]
         assert result.endswith("<br/>")
+
+    def test_table_column_width_aligned(self) -> None:
+        """Test that aligned mode always uses tabulate."""
+        html = "<table><tr><th>H1</th><th>H2</th></tr><tr><td>A</td><td>B</td></tr></table>"
+        # Since it's aligned, the column should be aligned using spaces via tabulate.
+        converter = TableConverter(table_column_width="aligned")
+        result = converter.convert(html)
+        assert "  " in result
+        assert "| H1   | H2   |" in result
+
+    def test_table_column_width_compact(self) -> None:
+        """Test that compact mode never pads with spaces."""
+        html = "<table><tr><th>H1</th><th>H2</th></tr><tr><td>A</td><td>B</td></tr></table>"
+        converter = TableConverter(table_column_width="compact")
+        result = converter.convert(html)
+        assert "  " not in result
+        assert "| H1 | H2 |" in result
+        assert "| A | B |" in result
+
+    def test_table_column_width_compact_escapes_pipes(self) -> None:
+        """Compact mode must escape literal pipe characters inside cell text."""
+        html = "<table><tr><th>H1</th></tr><tr><td>a|b</td></tr></table>"
+        converter = TableConverter(table_column_width="compact")
+        result = converter.convert(html)
+        assert "| a\\|b |" in result
+
+    def test_table_column_width_mixed_normal(self) -> None:
+        """Test that mixed mode keeps small tables aligned."""
+        html = "<table><tr><th>H1</th><th>H2</th></tr><tr><td>A</td><td>B</td></tr></table>"
+        converter = TableConverter(table_column_width="mixed")
+        result = converter.convert(html)
+        assert "  " in result
+        assert "| H1   | H2   |" in result
+
+    def test_table_column_width_mixed_nested(self) -> None:
+        """Test that mixed mode automatically uses compact mode for nested tables."""
+        html = """
+        <table>
+            <tr><th>Header</th></tr>
+            <tr>
+                <td>
+                    <table>
+                        <tr><td>Inner</td></tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+        """
+        converter = TableConverter(table_column_width="mixed")
+        result = converter.convert(html)
+        # The outer table contains a nested table, so it should be compact (no space padding).
+        assert "  " not in result
+
+    def test_table_column_width_mixed_long(self) -> None:
+        """Test that mixed mode falls back to compact mode for wide tables."""
+        # Create a table that is wider than 120 characters when aligned.
+        long_text = "x" * 125
+        html = f"<table><tr><th>Header</th></tr><tr><td>{long_text}</td></tr></table>"
+        converter = TableConverter(table_column_width="mixed")
+        result = converter.convert(html)
+        # Should be formatted compactly
+        assert "  " not in result


### PR DESCRIPTION
### Description

This Pull Request implements the proposed `table_column_width` configuration option to allow users to select between:
* `"aligned"`: Always align table columns using spaces via `tabulate` (the legacy behavior).
* `"mixed"` (Default): Keeps simple, narrow tables aligned, but automatically falls back to compact mode if a cell contains a nested `<table>` tag OR the total aligned table width exceeds **120 characters**.
* `"compact"`: Never align column widths. Output tight, GFM-compliant pipe tables without space padding.

This gives the best of both worlds: simple tables remain visually aligned for easy plain-text editing, while complex, nested, or extremely wide tables are formatted compactly to avoid massive space-padding clutter.

### Changes Included
- Added `table_column_width` settings literal field on Pydantic's `ExportConfig` model in `confluence_markdown_exporter/utils/app_data_store.py`.
- Integrated the formatting heuristic in `TableConverter._format_table` in `confluence_markdown_exporter/utils/table_converter.py`.
- Refactored `Page.convert_page_properties` to format Meta Bind VIEW fields appropriately in `confluence_markdown_exporter/confluence.py`.
- Added comprehensive unit tests in `tests/unit/utils/test_table_converter.py` and updated user documentation in `docs/configuration/options.md`.

All tests and linter checks pass cleanly.
