### PR TITLE
fix: allow dots in personal space keys in cloud URL parser

### DIFF
--- a/confluence_markdown_exporter/api_clients.py
+++ b/confluence_markdown_exporter/api_clients.py
@@ -105,7 +105,7 @@ class ConfluenceRef(BaseModel):
 # 1) Cloud [/wiki]/spaces/{space_key}[/pages/{page_id}[/{page_title}]]
 _CLOUD_URL_RE = re.compile(
     r"^(?:/ex/confluence/[^/]+)?(?:/wiki)?/spaces/"
-    r"(?P<space_key>[A-Za-z0-9_~-]+)"
+    r"(?P<space_key>[A-Za-z0-9_~.-]+)"
     r"(?:/pages/(?P<page_id>\d+)(?:/(?P<page_title>[^/?#]+))?)?"
     r"(?:/(?!pages/)[^/?#]+)?/?$"
 )

--- a/tests/unit/test_api_clients.py
+++ b/tests/unit/test_api_clients.py
@@ -122,6 +122,21 @@ _PARSE_CONFLUENCE_PATH_CASES = [
         "/spaces/SPACEKEY/pages/123456789/Page+Title",
         ConfluenceRef(space_key="SPACEKEY", page_id=123456789, page_title="Page Title"),
     ),
+    # Personal space keys are derived from usernames and contain a dot
+    # (~first.last). Follow-up to #204, which added "~" but not ".".
+    (
+        "https://company.atlassian.net/wiki/spaces/~jane.doe",
+        ConfluenceRef(space_key="~jane.doe"),
+    ),
+    (
+        "/spaces/~jane.doe/pages/123456789/Page+Title",
+        ConfluenceRef(space_key="~jane.doe", page_id=123456789, page_title="Page Title"),
+    ),
+    (
+        "/spaces/~jane.doe/overview",
+        ConfluenceRef(space_key="~jane.doe"),
+    ),
+
 ]
 
 


### PR DESCRIPTION
## Summary

Personal Confluence space keys are derived from usernames and commonly
contain a dot (e.g. `~jane.doe`). The cloud URL parser's `space_key`
character class allows `~` (added in #204) but not `.`, so a URL like
`/spaces/~jane.doe` fails the cloud pattern and falls through to the
server pattern, which greedily captures the literal `spaces` segment as
the key. The export then fails with the misleading:

```text
ApiError: There is no space with the given key, or the calling user does not have permission to view the space
```

where the attempted key is literally `spaces`

This is a follow-up to #204: that PR enabled `~` for personal spaces,
but real personal space keys almost always include a dot, so the cloud
parser still rejects them

Fix: add `.` to the cloud `space_key` character class. Server URLs and
regular space keys are unaffected

## Test Plan

- Added parametrized cases to `TestParseConfluencePath` covering `~jane.doe` (bare URL, with page path, with `/overview`)
- `uv run pytest tests/unit/test_api_clients.py` - green
- `uv run ruff check` - clean