### PR TITLE
fix(confluence): stop stripping multi-column layouts on export

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1905,14 +1905,23 @@ class Page(Document):
         def convert_column_layout(
             self, el: BeautifulSoup, text: str, parent_tags: list[str]
         ) -> str:
-            cells = el.find_all("div", {"class": "cell"})
+            """Render a Confluence column layout by stacking its cells vertically.
 
-            if len(cells) < 2:  # noqa: PLR2004
+            Markdown has no native columns, so each cell's content is converted
+            through its normal block-level handlers and the cells are joined
+            vertically. This preserves images, lists, tables and the TOC, which
+            a single-row table would otherwise flatten or drop.
+            """
+            cells = el.find_all("div", {"class": "cell"})
+            if not cells:
                 return super().convert_div(el, text, parent_tags)
 
-            html = f"<table><tr>{''.join([f'<td>{cell!s}</td>' for cell in cells])}</tr></table>"
+            parts = [self.process_tag(cell, parent_tags).strip() for cell in cells]
+            parts = [part for part in parts if part]
+            if not parts:
+                return ""
 
-            return self.convert_table(BeautifulSoup(html, "html.parser"), text, parent_tags)
+            return "\n\n" + "\n\n".join(parts) + "\n\n"
 
         def convert_jira_table(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
             jira_tables = BeautifulSoup(self.page.body_export, "html.parser").find_all(

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1912,7 +1912,10 @@ class Page(Document):
             vertically. This preserves images, lists, tables and the TOC, which
             a single-row table would otherwise flatten or drop.
             """
-            cells = el.find_all("div", {"class": "cell"})
+            # recursive=False so a nested column layout's cells are not also
+            # collected here; they are rendered when process_tag recurses into
+            # the parent cell. Cells are always direct children of columnLayout.
+            cells = el.find_all("div", {"class": "cell"}, recursive=False)
             if not cells:
                 return super().convert_div(el, text, parent_tags)
 

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1905,3 +1905,23 @@ class TestColumnLayoutConversion:
         )
         result = converter.convert(html)
         assert "Only column." in result
+
+    def test_nested_column_layout_not_duplicated(self, converter: Page.Converter) -> None:
+        """A column layout nested inside a cell must render its content once."""
+        html = (
+            '<div class="columnLayout two-equal">'
+            '<div class="cell normal"><div class="innerCell">'
+            "<p>Outer A</p>"
+            '<div class="columnLayout two-equal">'
+            '<div class="cell normal"><div class="innerCell"><p>Inner X</p></div></div>'
+            '<div class="cell normal"><div class="innerCell"><p>Inner Y</p></div></div>'
+            "</div>"
+            "</div></div>"
+            '<div class="cell normal"><div class="innerCell"><p>Outer B</p></div></div>'
+            "</div>"
+        )
+        result = converter.convert(html)
+        assert result.count("Inner X") == 1
+        assert result.count("Inner Y") == 1
+        assert result.count("Outer A") == 1
+        assert result.count("Outer B") == 1

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1853,3 +1853,55 @@ class TestAbsoluteUrlPageLinks:
 
         PageTitleRegistry.reset()
         assert result == "[[Legacy Page]]"
+
+
+class TestColumnLayoutConversion:
+    """Confluence multi-column layouts must not be stripped from the output.
+
+    Regression test for issue #262: ``convert_column_layout`` previously wrapped
+    the cells in a table and passed the whole BeautifulSoup *document* to
+    ``convert_table``, which finds rows with ``recursive=False`` and therefore
+    matched none, silently dropping the entire layout. Layouts are now rendered
+    by stacking each cell's content vertically.
+    """
+
+    TWO_COLUMN_HTML = (
+        '<div class="contentLayout2">'
+        '<div class="columnLayout two-right-sidebar" data-layout="two-right-sidebar">'
+        '<div class="cell normal"><div class="innerCell">'
+        "<p>Left column intro.</p>"
+        "<ul><li><p>First</p></li><li><p>Second</p></li></ul>"
+        "</div></div>"
+        '<div class="cell aside"><div class="innerCell">'
+        "<p>Right column text.</p>"
+        "</div></div>"
+        "</div></div>"
+    )
+
+    def test_two_column_layout_content_preserved(self, converter: Page.Converter) -> None:
+        result = converter.convert(self.TWO_COLUMN_HTML)
+        assert result.strip(), "column layout must not be stripped to empty"
+        for expected in ("Left column intro.", "First", "Second", "Right column text."):
+            assert expected in result
+
+    def test_two_column_layout_not_rendered_as_table(self, converter: Page.Converter) -> None:
+        result = converter.convert(self.TWO_COLUMN_HTML)
+        assert "| --- |" not in result
+        assert "|---|" not in result
+
+    def test_two_column_layout_renders_list_as_markdown_list(
+        self, converter: Page.Converter
+    ) -> None:
+        result = converter.convert(self.TWO_COLUMN_HTML)
+        assert "- First" in result
+        assert "- Second" in result
+
+    def test_single_cell_layout_content_preserved(self, converter: Page.Converter) -> None:
+        html = (
+            '<div class="columnLayout fixed-width" data-layout="fixed-width">'
+            '<div class="cell normal"><div class="innerCell">'
+            "<p>Only column.</p>"
+            "</div></div></div>"
+        )
+        result = converter.convert(html)
+        assert "Only column." in result


### PR DESCRIPTION
## What

Render Confluence multi-column layouts by stacking each cell's content vertically, instead of wrapping the cells in a single-row table.

## Why

Closes #262.

`convert_column_layout` built an HTML table from the layout cells and passed the whole `BeautifulSoup` **document** to `convert_table`. After `convert_table` was refactored to locate rows with `find_all(..., recursive=False)`, a document's only direct child is `<table>` (not `<tr>`/`<tbody>`), so **no rows matched and the method returned `""`** — silently dropping the entire column layout from the export.

Reproduced against two real pages: the layouts (intro text, bullet lists, a Table of Contents, and an in-body page-properties table) were completely missing from the output.

## How

Each cell is now converted through its normal block-level handlers and the cells are joined vertically. Markdown has no native columns, and stacking preserves images, lists, nested tables and the TOC that a single-row table would otherwise flatten or drop.

Cells are collected with `recursive=False` so that a column layout **nested inside a cell** is not collected twice (once at the top level and again when `process_tag` recurses into the parent cell). Cells are always direct children of `columnLayout`.

## Tests

- Added `TestColumnLayoutConversion`:
  - content is preserved (not stripped to empty)
  - layout is not rendered as a pipe table
  - lists render as markdown lists
  - single-cell layouts are preserved
  - nested column layouts are not duplicated
- The content tests fail on the old code and pass with this change.
- Full suite: `uv run pytest` → 433 passed.
- `uv run ruff check` → clean.