### PR TITLE
fix: fetch all Page Properties Report rows instead of first page

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -4,6 +4,7 @@ https://developer.atlassian.com/cloud/confluence/rest/v1/intro
 """
 
 import functools
+import html
 import json
 import logging
 import mimetypes
@@ -77,6 +78,9 @@ StrPath: TypeAlias = str | PathLike[str]
 
 logger = logging.getLogger(__name__)
 _MAX_UNICODE_CODEPOINT = 0x10FFFF
+
+# Rows requested per call when fetching all Page Properties Report entries.
+_REPORT_FETCH_PAGE_SIZE = 50
 
 _RE_RGB_BG = re.compile(r"background-color:\s*rgb\((\d+),\s*(\d+),\s*(\d+)\)")
 _RE_RGB_COLOR = re.compile(r"(?<![a-z-])color:\s*rgb\((\d+),\s*(\d+),\s*(\d+)\)")
@@ -2710,11 +2714,89 @@ class Page(Document):
                 if dql is not None:
                     return f"\n```dataview\n{dql}\n```\n"
 
-            soup = BeautifulSoup(self.page.body_export, "html.parser")
-            table = soup.find("table", {"data-cql": data_cql})
-            if not table:
+            table: Tag | None = self._fetch_page_properties_report_table(el)
+            if table is None:
+                # Fall back to the server-rendered snapshot, which only contains
+                # the first page of results (the macro's configured page size).
+                soup = BeautifulSoup(self.page.body_export, "html.parser")
+                table = cast("Tag | None", soup.find("table", {"data-cql": data_cql}))
+            if table is None:
                 return ""
             return super().convert_table(table, "", parent_tags)  # type: ignore -
+
+        def _fetch_page_properties_report_table(self, el: BeautifulSoup) -> Tag | None:
+            """Fetch all report rows via the masterdetail REST endpoint.
+
+            The rendered table in ``body.export_view`` only contains the first
+            page of results, so all rows are re-fetched through the endpoint the
+            macro's own pagination uses. Returns None if the endpoint is
+            unavailable or returns no rows, so the caller can fall back to the
+            rendered snapshot.
+            """
+            url = "rest/masterdetail/1.0/detailssummary/lines"
+            params: dict[str, Any] = {
+                "cql": str(el.get("data-cql", "")),
+                "spaceKey": str(el.get("data-current-space-key", "")),
+                "headings": str(el.get("data-headings", "")),
+                "sortBy": str(el.get("data-sort-by", "")),
+                "reverseSort": str(el.get("data-reverse-sort", "false")),
+                "pageSize": _REPORT_FETCH_PAGE_SIZE,
+                "pageIndex": 0,
+            }
+            lines: list[dict[str, Any]] = []
+            try:
+                client = get_thread_confluence(self.page.base_url)
+                response = cast("dict", client.get(url, params=params))
+                lines.extend(response.get("detailLines", []))
+                total_pages = int(response.get("totalPages", 1))
+                for page_index in range(1, total_pages):
+                    response = cast(
+                        "dict", client.get(url, params={**params, "pageIndex": page_index})
+                    )
+                    page_lines = response.get("detailLines", [])
+                    if not page_lines:
+                        break
+                    lines.extend(page_lines)
+            except HTTPError as e:
+                logger.warning(
+                    f"Failed to fetch Page Properties Report rows for page "
+                    f"'{self.page.title}' (ID: {self.page.id}): {e}. "
+                    f"Falling back to the rendered table snapshot."
+                )
+                return None
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    f"Unexpected error fetching Page Properties Report rows for page "
+                    f"ID {self.page.id}. Falling back to the rendered table snapshot.",
+                    exc_info=True,
+                )
+                return None
+            if not lines:
+                return None
+            return self._build_report_table(el, lines)
+
+        def _build_report_table(self, el: BeautifulSoup, lines: list[dict[str, Any]]) -> Tag | None:
+            """Assemble a full HTML table from masterdetail detail lines."""
+            first_col = str(el.get("data-first-column-heading") or "Title")
+            headings = [h.strip() for h in str(el.get("data-headings", "")).split(",") if h.strip()]
+            header = "".join(f"<th>{html.escape(h)}</th>" for h in [first_col, *headings])
+            rows: list[str] = []
+            for line in lines:
+                title = html.escape(str(line.get("title", "")))
+                href = html.escape(str(line.get("relativeLink", "")), quote=True)
+                page_id = html.escape(str(line.get("id", "")))
+                link = (
+                    f'<a href="{href}" data-linked-resource-type="page" '
+                    f'data-linked-resource-id="{page_id}">{title}</a>'
+                )
+                # Detail cells are server-rendered HTML fragments; insert verbatim.
+                cells = "".join(f"<td>{detail}</td>" for detail in line.get("details", []))
+                rows.append(f"<tr><td>{link}</td>{cells}</tr>")
+            table_html = (
+                f"<table><thead><tr>{header}</tr></thead><tbody>{''.join(rows)}</tbody></table>"
+            )
+            table = BeautifulSoup(table_html, "html.parser").find("table")
+            return table if isinstance(table, Tag) else None
 
         def _cql_to_dataview(self, el: BeautifulSoup, cql: str) -> str | None:
             """Translate a Confluence CQL query to an Obsidian Dataview DQL query.

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2730,14 +2730,20 @@ class Page(Document):
             The rendered table in ``body.export_view`` only contains the first
             page of results, so all rows are re-fetched through the endpoint the
             macro's own pagination uses. Returns None if the endpoint is
-            unavailable or returns no rows, so the caller can fall back to the
+            unavailable, returns no or incomplete rows, or the macro has no
+            explicit column configuration, so the caller can fall back to the
             rendered snapshot.
             """
+            headings = str(el.get("data-headings", ""))
+            if not headings.strip():
+                # Without explicit columns the server derives the headings, so a
+                # rebuilt header would not match the detail cells.
+                return None
             url = "rest/masterdetail/1.0/detailssummary/lines"
             params: dict[str, Any] = {
                 "cql": str(el.get("data-cql", "")),
                 "spaceKey": str(el.get("data-current-space-key", "")),
-                "headings": str(el.get("data-headings", "")),
+                "headings": headings,
                 "sortBy": str(el.get("data-sort-by", "")),
                 "reverseSort": str(el.get("data-reverse-sort", "false")),
                 "pageSize": _REPORT_FETCH_PAGE_SIZE,
@@ -2748,6 +2754,7 @@ class Page(Document):
                 client = get_thread_confluence(self.page.base_url)
                 response = cast("dict", client.get(url, params=params))
                 lines.extend(response.get("detailLines", []))
+                total = int(response.get("total") or 0)
                 total_pages = int(response.get("totalPages", 1))
                 for page_index in range(1, total_pages):
                     response = cast(
@@ -2757,6 +2764,13 @@ class Page(Document):
                     if not page_lines:
                         break
                     lines.extend(page_lines)
+                if total and len(lines) < total:
+                    logger.warning(
+                        f"Fetched only {len(lines)} of {total} Page Properties Report rows "
+                        f"for page '{self.page.title}' (ID: {self.page.id}). "
+                        f"Falling back to the rendered table snapshot."
+                    )
+                    return None
                 if not lines:
                     return None
                 return self._build_report_table(el, lines)
@@ -2770,7 +2784,8 @@ class Page(Document):
             except Exception:  # noqa: BLE001
                 logger.warning(
                     f"Unexpected error fetching Page Properties Report rows for page "
-                    f"ID {self.page.id}. Falling back to the rendered table snapshot.",
+                    f"'{self.page.title}' (ID: {self.page.id}). "
+                    f"Falling back to the rendered table snapshot.",
                     exc_info=True,
                 )
                 return None
@@ -2782,13 +2797,18 @@ class Page(Document):
             header = "".join(f"<th>{html.escape(h)}</th>" for h in [first_col, *headings])
             rows: list[str] = []
             for line in lines:
-                title = html.escape(str(line.get("title", "")))
-                href = html.escape(str(line.get("relativeLink", "")), quote=True)
-                page_id = html.escape(str(line.get("id", "")))
-                link = (
-                    f'<a href="{href}" data-linked-resource-type="page" '
-                    f'data-linked-resource-id="{page_id}">{title}</a>'
-                )
+                title = html.escape(str(line.get("title") or ""))
+                href = html.escape(str(line.get("relativeLink") or ""), quote=True)
+                page_id = str(line.get("id") or "")
+                if page_id.isdecimal():
+                    link = (
+                        f'<a href="{href}" data-linked-resource-type="page" '
+                        f'data-linked-resource-id="{page_id}">{title}</a>'
+                    )
+                else:
+                    # Without a numeric page id the link cannot be resolved to an
+                    # exported page; keep the plain title text.
+                    link = title
                 # Detail cells are server-rendered HTML fragments; insert verbatim.
                 cells = "".join(f"<td>{detail}</td>" for detail in line.get("details") or [])
                 rows.append(f"<tr><td>{link}</td>{cells}</tr>")

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2757,6 +2757,9 @@ class Page(Document):
                     if not page_lines:
                         break
                     lines.extend(page_lines)
+                if not lines:
+                    return None
+                return self._build_report_table(el, lines)
             except HTTPError as e:
                 logger.warning(
                     f"Failed to fetch Page Properties Report rows for page "
@@ -2771,9 +2774,6 @@ class Page(Document):
                     exc_info=True,
                 )
                 return None
-            if not lines:
-                return None
-            return self._build_report_table(el, lines)
 
         def _build_report_table(self, el: BeautifulSoup, lines: list[dict[str, Any]]) -> Tag | None:
             """Assemble a full HTML table from masterdetail detail lines."""
@@ -2790,7 +2790,7 @@ class Page(Document):
                     f'data-linked-resource-id="{page_id}">{title}</a>'
                 )
                 # Detail cells are server-rendered HTML fragments; insert verbatim.
-                cells = "".join(f"<td>{detail}</td>" for detail in line.get("details", []))
+                cells = "".join(f"<td>{detail}</td>" for detail in line.get("details") or [])
                 rows.append(f"<tr><td>{link}</td>{cells}</tr>")
             table_html = (
                 f"<table><thead><tr>{header}</tr></thead><tbody>{''.join(rows)}</tbody></table>"

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -479,7 +479,8 @@ class ExportConfig(BaseModel):
         title="Page Properties Report Format",
         description=(
             "How to render Confluence Page Properties Report macros.\n"
-            "  frozen: export the rendered table as a static markdown table (default)\n"
+            "  frozen: export all report rows as a static markdown table (default); falls\n"
+            "    back to the rendered table snapshot if the rows cannot be fetched\n"
             "  dataview: translate the CQL query to an Obsidian Dataview DQL code block;\n"
             "    requires the Dataview plugin and all referenced child pages to be exported\n"
             "    with their page properties as frontmatter; falls back to frozen on failure"

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -139,7 +139,7 @@ Controls how Confluence Page Properties Report macros (dynamic cross-page proper
 
 | Value      | Description                                                                                                                                                                                                                                                                                                |
 | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `frozen`   | Export the rendered table as a static markdown table snapshot (default)                                                                                                                                                                                                                                    |
+| `frozen`   | Export all report rows as a static markdown table (default); rows are fetched through the same API the macro's pagination uses, so the table is not limited to the macro's configured page size; falls back to the rendered table snapshot if the rows cannot be fetched                                   |
 | `dataview` | Translate the CQL query to an [Obsidian Dataview](https://blacksmithgu.github.io/obsidian-dataview/) DQL code block; requires the Dataview plugin and all referenced child pages to be exported with their page properties as front matter; falls back to a frozen table if the query cannot be translated |
 
 - Default: `frozen`

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
+from requests import HTTPError
 
 from confluence_markdown_exporter.confluence import Attachment
 from confluence_markdown_exporter.confluence import Page
@@ -1539,6 +1540,7 @@ class TestPagePropertiesReportDataview:
 
             self.id = 42
             self.title = "Test Page"
+            self.base_url = "https://confluence.example.com"
             self.html = ""
             self.labels: list = []
             self.ancestors: list = []
@@ -1601,14 +1603,170 @@ class TestPagePropertiesReportDataview:
             result = converter.convert(self._REPORT_HTML)
         assert "SORT title ASC" in result
 
-    def test_frozen_table_when_format_is_frozen(self) -> None:
+    def test_frozen_table_falls_back_to_snapshot_when_endpoint_unavailable(self) -> None:
         page = self._MockPageWithExport(body_export=self._BODY_EXPORT)
         converter = Page.Converter(page)
-        with patch("confluence_markdown_exporter.confluence.settings") as s:
+        client = MagicMock()
+        client.get.side_effect = HTTPError("404 Client Error")
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.get_thread_confluence",
+                return_value=client,
+            ),
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
             s.export.page_properties_report_format = "frozen"
             result = converter.convert(self._REPORT_HTML)
         assert "```dataview" not in result
         assert "Page A" in result
+
+
+class TestPagePropertiesReportFrozenFetchesAllRows:
+    """Frozen report tables are rebuilt with all rows from the masterdetail API."""
+
+    _REPORT_HTML = TestPagePropertiesReportDataview._REPORT_HTML
+    _BODY_EXPORT = TestPagePropertiesReportDataview._BODY_EXPORT
+
+    @staticmethod
+    def _detail_line(page_id: int, title: str, details: list[str]) -> dict:
+        return {
+            "id": page_id,
+            "title": title,
+            "relativeLink": f"/display/TS/{title.replace(' ', '+')}",
+            "details": details,
+        }
+
+    @staticmethod
+    def _make_linked_page(page_id: int, title: str) -> Page:
+        space = Space(
+            base_url="https://confluence.example.com",
+            key="TS",
+            name="Test Space",
+            description="",
+            homepage=0,
+        )
+        version = Version(
+            number=1,
+            by=User(
+                account_id="u1",
+                display_name="User",
+                username="user",
+                public_name="",
+                email="",
+            ),
+            when="2024-01-01T00:00:00Z",
+            friendly_when="Jan 1",
+        )
+        return Page(
+            base_url="https://confluence.example.com",
+            id=page_id,
+            title=title,
+            space=space,
+            ancestors=[],
+            version=version,
+            body="",
+            body_export="",
+            editor2="",
+            body_storage="",
+            labels=[],
+            attachments=[],
+        )
+
+    def _convert_frozen(self, client: MagicMock) -> str:
+        from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
+
+        PageTitleRegistry.reset()
+        page = TestPagePropertiesReportDataview._MockPageWithExport(body_export=self._BODY_EXPORT)
+        converter = Page.Converter(page)
+        linked_titles = {101: "Page A", 102: "Page B", 103: "Page C"}
+
+        def _from_id(page_id: int, _base_url: str = "") -> Page:
+            return self._make_linked_page(int(page_id), linked_titles[int(page_id)])
+
+        try:
+            with (
+                patch(
+                    "confluence_markdown_exporter.confluence.get_thread_confluence",
+                    return_value=client,
+                ),
+                patch(
+                    "confluence_markdown_exporter.confluence.Page.from_id",
+                    side_effect=_from_id,
+                ),
+                patch("confluence_markdown_exporter.confluence.settings") as s,
+            ):
+                s.export.page_properties_report_format = "frozen"
+                s.export.page_href = "wiki"
+                return converter.convert(self._REPORT_HTML)
+        finally:
+            PageTitleRegistry.reset()
+
+    def test_all_rows_fetched_across_pages(self) -> None:
+        client = MagicMock()
+        client.get.side_effect = [
+            {
+                "total": 3,
+                "totalPages": 2,
+                "currentPage": 0,
+                "detailLines": [
+                    self._detail_line(101, "Page A", ["<p>v1.0</p>", "<p>Yes</p>"]),
+                    self._detail_line(102, "Page B", ["<p>v2.0</p>", "<p>No</p>"]),
+                ],
+            },
+            {
+                "total": 3,
+                "totalPages": 2,
+                "currentPage": 1,
+                "detailLines": [
+                    self._detail_line(103, "Page C", ["<p>v3.0</p>", "<p>Yes</p>"]),
+                ],
+            },
+        ]
+
+        result = self._convert_frozen(client)
+
+        assert "Page A" in result
+        assert "Page B" in result
+        assert "Page C" in result
+        assert "Tool Version" in result
+        assert "Approved for Use" in result
+        assert "v2.0" in result
+        assert "v3.0" in result
+        assert client.get.call_count == 2
+        first_params = client.get.call_args_list[0].kwargs["params"]
+        second_params = client.get.call_args_list[1].kwargs["params"]
+        assert first_params["pageIndex"] == 0
+        assert second_params["pageIndex"] == 1
+        assert first_params["cql"] == 'label = "tool-validation" and parent = "42"'
+
+    def test_single_page_report_makes_one_request(self) -> None:
+        client = MagicMock()
+        client.get.side_effect = [
+            {
+                "total": 1,
+                "totalPages": 1,
+                "currentPage": 0,
+                "detailLines": [
+                    self._detail_line(101, "Page A", ["<p>v1.0</p>", "<p>Yes</p>"]),
+                ],
+            },
+        ]
+
+        result = self._convert_frozen(client)
+
+        assert "Page A" in result
+        assert client.get.call_count == 1
+
+    def test_fallback_to_snapshot_when_no_detail_lines(self) -> None:
+        client = MagicMock()
+        client.get.side_effect = [
+            {"total": 0, "totalPages": 0, "currentPage": 0, "detailLines": []},
+        ]
+
+        result = self._convert_frozen(client)
+
+        assert "Page A" in result
+        assert client.get.call_count == 1
 
 
 class TestAttachmentTemplateVars:

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1627,6 +1627,18 @@ class TestPagePropertiesReportFrozenFetchesAllRows:
     _REPORT_HTML = TestPagePropertiesReportDataview._REPORT_HTML
     _BODY_EXPORT = TestPagePropertiesReportDataview._BODY_EXPORT
 
+    _REPORT_HTML_NO_HEADINGS = (
+        '<table class="aui metadata-summary-macro null"'
+        ' data-cql=\'label = "tool-validation" and parent = "42"\''
+        ' data-current-content-id="42"'
+        ' data-current-space-key="TS"'
+        ' data-first-column-heading="Title"'
+        ' data-headings=""'
+        ' data-sort-by="Title"'
+        ' data-reverse-sort="false">'
+        "</table>"
+    )
+
     @staticmethod
     def _detail_line(page_id: int, title: str, details: list[str]) -> dict:
         return {
@@ -1672,7 +1684,7 @@ class TestPagePropertiesReportFrozenFetchesAllRows:
             attachments=[],
         )
 
-    def _convert_frozen(self, client: MagicMock) -> str:
+    def _convert_frozen(self, client: MagicMock, report_html: str | None = None) -> str:
         from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
 
         PageTitleRegistry.reset()
@@ -1697,7 +1709,7 @@ class TestPagePropertiesReportFrozenFetchesAllRows:
             ):
                 s.export.page_properties_report_format = "frozen"
                 s.export.page_href = "wiki"
-                return converter.convert(self._REPORT_HTML)
+                return converter.convert(report_html or self._REPORT_HTML)
         finally:
             PageTitleRegistry.reset()
 
@@ -1794,6 +1806,77 @@ class TestPagePropertiesReportFrozenFetchesAllRows:
         result = self._convert_frozen(client)
 
         assert "Page B" in result
+
+    def test_fallback_when_headings_attribute_is_empty(self) -> None:
+        client = MagicMock()
+
+        result = self._convert_frozen(client, report_html=self._REPORT_HTML_NO_HEADINGS)
+
+        assert "Page A" in result
+        client.get.assert_not_called()
+
+    def test_row_without_page_id_renders_plain_title(self) -> None:
+        client = MagicMock()
+        client.get.side_effect = [
+            {
+                "total": 1,
+                "totalPages": 1,
+                "currentPage": 0,
+                "detailLines": [
+                    {
+                        "id": None,
+                        "title": "No Id Page",
+                        "relativeLink": "",
+                        "details": ["<p>v9</p>"],
+                    },
+                ],
+            },
+        ]
+
+        result = self._convert_frozen(client)
+
+        assert "No Id Page" in result
+        assert "v9" in result
+
+    def test_fallback_when_later_page_is_empty(self) -> None:
+        client = MagicMock()
+        client.get.side_effect = [
+            {
+                "total": 3,
+                "totalPages": 2,
+                "currentPage": 0,
+                "detailLines": [
+                    self._detail_line(101, "Page A", ["<p>v1.0</p>", "<p>Yes</p>"]),
+                    self._detail_line(102, "Page B", ["<p>v2.0</p>", "<p>No</p>"]),
+                ],
+            },
+            {"total": 3, "totalPages": 2, "currentPage": 1, "detailLines": []},
+        ]
+
+        result = self._convert_frozen(client)
+
+        assert "Page A" in result
+        assert "Page B" not in result
+
+    def test_fallback_when_second_page_request_fails(self) -> None:
+        client = MagicMock()
+        client.get.side_effect = [
+            {
+                "total": 3,
+                "totalPages": 2,
+                "currentPage": 0,
+                "detailLines": [
+                    self._detail_line(101, "Page A", ["<p>v1.0</p>", "<p>Yes</p>"]),
+                    self._detail_line(102, "Page B", ["<p>v2.0</p>", "<p>No</p>"]),
+                ],
+            },
+            HTTPError("500 Server Error"),
+        ]
+
+        result = self._convert_frozen(client)
+
+        assert "Page A" in result
+        assert "Page B" not in result
 
 
 class TestAttachmentTemplateVars:

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1768,6 +1768,33 @@ class TestPagePropertiesReportFrozenFetchesAllRows:
         assert "Page A" in result
         assert client.get.call_count == 1
 
+    def test_fallback_to_snapshot_when_response_is_malformed(self) -> None:
+        client = MagicMock()
+        client.get.side_effect = [
+            {"total": 1, "totalPages": 1, "currentPage": 0, "detailLines": ["not-a-dict"]},
+        ]
+
+        result = self._convert_frozen(client)
+
+        assert "Page A" in result
+
+    def test_row_with_null_details_is_kept(self) -> None:
+        client = MagicMock()
+        client.get.side_effect = [
+            {
+                "total": 1,
+                "totalPages": 1,
+                "currentPage": 0,
+                "detailLines": [
+                    {"id": 102, "title": "Page B", "relativeLink": "/x", "details": None},
+                ],
+            },
+        ]
+
+        result = self._convert_frozen(client)
+
+        assert "Page B" in result
+
 
 class TestAttachmentTemplateVars:
     """`attachment_file_id` falls back to the content id when fileId is empty."""


### PR DESCRIPTION
## Summary

Fixes #276.

When a page contains a Page Properties Report macro (`detailssummary`) with "Number of items to display" set to e.g. 30, the exported Markdown table contained only those first 30 rows instead of all matching items. The `frozen` export copied the table pre-rendered into `body.export_view`, which Confluence truncates to the macro's configured page size; the `data-cql` attribute was never executed against the API.

This change makes the `frozen` format fetch **all** report rows through `rest/masterdetail/1.0/detailssummary/lines` (the same REST endpoint the macro's own pagination UI uses), looping over `pageIndex` until `totalPages` is exhausted, and rebuilds one complete table:

- New `_fetch_page_properties_report_table` pages through the endpoint (50 rows per request) using the parameters already present on the rendered table (`data-cql`, `data-current-space-key`, `data-headings`, `data-sort-by`, `data-reverse-sort`), so the report's configured sort order is preserved.
- New `_build_report_table` assembles the full HTML table. The first column is emitted as a proper page link (`data-linked-resource-type="page"` + `data-linked-resource-id`), so links resolve to exported `.md` paths exactly like native page links. Detail cells reuse the server-rendered HTML fragments, so no property-extraction logic is duplicated. Rows whose detail line has no numeric id keep the plain title text instead of a link.
- **Graceful degradation — the output can never get worse than before.** The export falls back to the previous behavior (the rendered snapshot) whenever the full row set cannot be trusted:
  - HTTP error from the endpoint (e.g. instances without it);
  - unexpected/malformed response shape;
  - empty result;
  - fewer rows collected than the response's reported `total` (a partial table that looks complete would silently drop rows);
  - the macro has no explicit column configuration (empty `data-headings`), where a rebuilt header would not match the server-derived detail cells.
- The `dataview` format is unchanged. Setting description and `docs/configuration/options.md` are updated accordingly.

## Test Plan

- New unit test class `TestPagePropertiesReportFrozenFetchesAllRows`:
  - rows merged across two API result pages (asserts `pageIndex` 0 and 1 are requested and all rows plus headings appear in the Markdown table);
  - single-page report performs exactly one request;
  - empty `detailLines` falls back to the rendered snapshot;
  - malformed response (non-dict detail line) falls back to the snapshot;
  - a detail line with `"details": null` keeps the row with the title link;
  - a detail line without a numeric id renders plain title text (no crash);
  - an empty later page falls back to the snapshot instead of exporting partial rows;
  - an HTTP error on the second page request discards partial rows and falls back;
  - empty `data-headings` skips the fetch entirely and keeps the snapshot.
- Updated `test_frozen_table_falls_back_to_snapshot_when_endpoint_unavailable`: an `HTTPError` from the endpoint falls back to the rendered snapshot.
- Full suite: 442 passed; `ruff check` clean.

### End-to-end verification on Confluence Cloud

Verified against a real Confluence Cloud instance with a Page Properties Report configured to 30 items per page and 35 matching pages:

- Before the fix, `body.export_view` contained a 30-row snapshot table (confirmed in the debug HTML dump); the export was truncated accordingly.
- With the fix, the exported Markdown table contains **all 35 rows**, in the report's configured order, with the first column resolving to the exported `.md` files. No fallback warnings were logged.
- Multi-page fetching was verified live against the same instance by calling the endpoint with a small page size (10): iterating `pageIndex` over the reported 4 `totalPages` collected all 35 rows with no duplicates or gaps across page boundaries — the same loop logic the production code uses.
- Cloud specifics confirmed: the export view renders the report with the same `metadata-summary-macro` / `data-cql` markup as Server/DC, and `rest/masterdetail/1.0/detailssummary/lines` is available on Cloud (served via the cloud gateway). The Cloud response omits the `total` field, which the completeness check tolerates (`response.get("total") or 0`).
- Data Center was not tested live; the endpoint and table markup originate from Server/DC, and instances without the endpoint keep today's behavior via the fallback.
