### PR TITLE
fix: export page properties report nested in third-party app macros

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -3,6 +3,7 @@
 https://developer.atlassian.com/cloud/confluence/rest/v1/intro
 """
 
+import copy
 import functools
 import html
 import json
@@ -1501,6 +1502,7 @@ class Page(Document):
             self._panel_icon_map_cache: dict[str, str] | None = None
             self._plantuml_index: int = 0
             self._storage_plantuml_macros_cache: list[Tag] | None = None
+            self._storage_soup_cache: BeautifulSoup | None = None
 
         @property
         def _colorid_map(self) -> dict[str, str]:
@@ -2607,6 +2609,10 @@ class Page(Document):
                 return html
 
             soup = BeautifulSoup(html, "html.parser")
+            # `get_text` ignores <script>/<style> contents (BeautifulSoup models them as
+            # Script/Stylesheet, which are excluded from the string traversal), so the
+            # iframe bootstrap script the placeholder always carries does not count as
+            # rendered content. Only a macro the app did not render server-side matches.
             placeholders = [
                 el
                 for el in soup.find_all("div", class_="ap-container")
@@ -2617,42 +2623,73 @@ class Page(Document):
             if not placeholders:
                 return html
 
-            export_tables: dict[str, Tag] = {}
-            export_soup = BeautifulSoup(self.page.body_export or "", "html.parser")
-            for table in export_soup.find_all("table", class_="metadata-summary-macro"):
-                cql = table.get("data-cql") if isinstance(table, Tag) else None
-                if isinstance(cql, str) and cql:
-                    export_tables.setdefault(_normalize_cql(cql), table)
-
+            export_tables = self._export_report_tables_by_cql()
             for placeholder in placeholders:
+                # An outer placeholder may have contained this one and been decomposed.
+                if placeholder.parent is None:
+                    continue
+                macro_id = str(placeholder.get("data-macro-id", ""))
                 tables: list[Tag] = []
-                for cql in self._nested_report_cqls(str(placeholder.get("data-macro-id", ""))):
+                for cql in self._nested_report_cqls(macro_id):
                     table = export_tables.get(_normalize_cql(cql))
-                    if table is not None:
-                        tables.append(table)
+                    if table is None:
+                        logger.warning(
+                            f"Page Properties Report nested in app macro '{macro_id}' on page "
+                            f"'{self.page.title}' (ID: {self.page.id}) has no matching table in "
+                            f"body.export_view and is omitted from the export. CQL: {cql}"
+                        )
+                        continue
+                    tables.append(table)
                 if not tables:
                     continue
                 for table in tables:
-                    placeholder.insert_before(table)
+                    # Copy: the same table may be referenced by more than one placeholder,
+                    # and inserting a live node moves it rather than duplicating it.
+                    placeholder.insert_before(copy.copy(table))
                 placeholder.decompose()
             return str(soup)
 
-        def _nested_report_cqls(self, macro_id: str) -> list[str]:
-            """Return the CQL of each Page Properties Report nested in an app macro.
+        def _export_report_tables_by_cql(self) -> dict[str, Tag]:
+            """Index the Page Properties Report tables rendered into body.export_view."""
+            tables: dict[str, Tag] = {}
+            soup = BeautifulSoup(self.page.body_export or "", "html.parser")
+            for table in soup.find_all("table", class_="metadata-summary-macro"):
+                cql = table.get("data-cql") if isinstance(table, Tag) else None
+                if not isinstance(cql, str) or not cql:
+                    continue
+                key = _normalize_cql(cql)
+                if key in tables:
+                    logger.warning(
+                        f"Page '{self.page.title}' (ID: {self.page.id}) has multiple Page "
+                        f"Properties Reports with identical CQL; the first rendered table "
+                        f"is used for all of them. CQL: {key}"
+                    )
+                    continue
+                tables[key] = table
+            return tables
 
-            body.storage is parsed with `html.parser` rather than the `xml` parser
-            used elsewhere: storage can contain HTML entities that are undefined in
-            XML (third-party macros emit e.g. `&sbquo;`), which puts lxml into error
-            recovery, where it silently drops unrelated entities such as the `&quot;`
-            wrapping CQL values. That corrupts the CQL and breaks the match below.
-            `html.parser` keeps the namespace prefixes, so both the prefixed and
-            unprefixed tag names are accepted.
+        @property
+        def _storage_soup(self) -> BeautifulSoup:
+            """Cache and return body.storage parsed for macro lookups.
+
+            Parsed with `html.parser` rather than the `xml` parser used elsewhere:
+            storage can contain HTML entities that are undefined in XML (third-party
+            macros emit e.g. `&sbquo;`), which puts lxml into error recovery, where it
+            silently drops unrelated entities such as the `&quot;` wrapping CQL values.
+            That corrupts the CQL and breaks the report lookup. `html.parser` keeps the
+            namespace prefixes, so both the prefixed and unprefixed tag names are
+            accepted by the callers.
             """
+            if self._storage_soup_cache is None:
+                self._storage_soup_cache = BeautifulSoup(self.page.body_storage, "html.parser")
+            return self._storage_soup_cache
+
+        def _nested_report_cqls(self, macro_id: str) -> list[str]:
+            """Return the CQL of each Page Properties Report nested in an app macro."""
             if not macro_id or not self.page.body_storage:
                 return []
 
-            soup = BeautifulSoup(self.page.body_storage, "html.parser")
-            for macro in soup.find_all(_AC_MACRO_TAGS):
+            for macro in self._storage_soup.find_all(_AC_MACRO_TAGS):
                 if not isinstance(macro, Tag) or _ac_attr(macro, "macro-id") != macro_id:
                     continue
                 cqls: list[str] = []

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2629,17 +2629,17 @@ class Page(Document):
                 if placeholder.parent is None:
                     continue
                 macro_id = str(placeholder.get("data-macro-id", ""))
-                tables: list[Tag] = []
-                for cql in self._nested_report_cqls(macro_id):
-                    table = export_tables.get(_normalize_cql(cql))
-                    if table is None:
-                        logger.warning(
-                            f"Page Properties Report nested in app macro '{macro_id}' on page "
-                            f"'{self.page.title}' (ID: {self.page.id}) has no matching table in "
-                            f"body.export_view and is omitted from the export. CQL: {cql}"
-                        )
-                        continue
-                    tables.append(table)
+                cqls = self._nested_report_cqls(macro_id)
+                if not cqls:
+                    # Most app macros legitimately wrap no report, so this is not a
+                    # warning; it is logged only to explain a placeholder left in place.
+                    logger.debug(
+                        f"App macro '{macro_id}' on page '{self.page.title}' "
+                        f"(ID: {self.page.id}) has no nested Page Properties Report in "
+                        f"body.storage; leaving the placeholder untouched."
+                    )
+                    continue
+                tables = self._report_tables_for_cqls(cqls, export_tables, macro_id)
                 if not tables:
                     continue
                 for table in tables:
@@ -2648,6 +2648,27 @@ class Page(Document):
                     placeholder.insert_before(copy.copy(table))
                 placeholder.decompose()
             return str(soup)
+
+        def _report_tables_for_cqls(
+            self, cqls: list[str], export_tables: dict[str, Tag], macro_id: str
+        ) -> list[Tag]:
+            """Resolve each nested report's CQL to its rendered body.export_view table."""
+            tables: list[Tag] = []
+            for cql in cqls:
+                table = export_tables.get(_normalize_cql(cql))
+                if table is None:
+                    # The CQL itself is macro configuration and can embed labels or
+                    # free-text filters, so it is kept out of the warning and logged
+                    # only at debug level.
+                    logger.warning(
+                        f"Page Properties Report nested in app macro '{macro_id}' on page "
+                        f"'{self.page.title}' (ID: {self.page.id}) has no matching table in "
+                        f"body.export_view and is omitted from the export."
+                    )
+                    logger.debug(f"Unmatched Page Properties Report CQL: {cql}")
+                    continue
+                tables.append(table)
+            return tables
 
         def _export_report_tables_by_cql(self) -> dict[str, Tag]:
             """Index the Page Properties Report tables rendered into body.export_view."""
@@ -2662,8 +2683,9 @@ class Page(Document):
                     logger.warning(
                         f"Page '{self.page.title}' (ID: {self.page.id}) has multiple Page "
                         f"Properties Reports with identical CQL; the first rendered table "
-                        f"is used for all of them. CQL: {key}"
+                        f"is used for all of them."
                     )
+                    logger.debug(f"Duplicate Page Properties Report CQL: {key}")
                     continue
                 tables[key] = table
             return tables

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -91,9 +91,31 @@ _RE_HEX_COLOR = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
 # (in matrix-style tables) to row-label <td>s. Treated as "no user-chosen colour".
 _DEFAULT_HEADER_BGS = frozenset({"#f4f5f7", "#f2f2f2"})
 
+# Storage-format tag names, with and without the `ac:` prefix. Which form is present
+# depends on the parser: `html.parser` keeps the prefix, the `xml` parser strips it.
+_AC_MACRO_TAGS = ["ac:structured-macro", "structured-macro"]
+_AC_PARAMETER_TAGS = ["ac:parameter", "parameter"]
+
 
 def _rgb_to_hex(r: int, g: int, b: int) -> str:
     return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _ac_attr(el: Tag, name: str) -> str:
+    """Read a storage-format attribute, with or without the `ac:` prefix."""
+    value = el.get(f"ac:{name}")
+    if value is None:
+        value = el.get(name, "")
+    return str(value)
+
+
+def _normalize_cql(cql: str) -> str:
+    """Normalize a CQL string so it can be used as a lookup key.
+
+    body.storage and body.export_view are produced by different renderers and may
+    differ in incidental whitespace, so collapse it before comparing.
+    """
+    return " ".join(cql.split())
 
 
 def _render_meta_bind_view_fields(props: dict[str, str], mode: str) -> str:
@@ -1562,6 +1584,7 @@ class Page(Document):
         @property
         def markdown(self) -> str:
             html = self._strip_excerpt_include_panel_titles(self.page.html)
+            html = self._inline_app_macro_bodies(html)
             md_body = self.convert(html)
             md_body = self._escape_template_placeholders(md_body)
             markdown = f"{self.front_matter}\n"
@@ -2565,6 +2588,83 @@ class Page(Document):
             content = el.find("div", class_="panelContent")
             if isinstance(content, Tag):
                 content.unwrap()
+
+        def _inline_app_macro_bodies(self, html: str) -> str:
+            """Splice Connect app macro bodies back into the rendered view HTML.
+
+            Confluence does not server-render the body of a Connect
+            `dynamicContentMacros` app macro (e.g. the StiltSoft Table Filter) into
+            body.view. It emits an empty `ap-container` placeholder and leaves the app
+            to render the body in an iframe, so a Page Properties Report nested in such
+            a macro never reaches `convert_table`. body.export_view does render the
+            report, with the wrapper stripped, so the placeholder is replaced with that
+            table and the regular report handling then applies unchanged.
+
+            The two are matched on the CQL of the nested `detailssummary` macro in
+            body.storage, because body.export_view carries no macro IDs.
+            """
+            if "ap-container" not in html:
+                return html
+
+            soup = BeautifulSoup(html, "html.parser")
+            placeholders = [
+                el
+                for el in soup.find_all("div", class_="ap-container")
+                if isinstance(el, Tag)
+                and el.get("data-hasbody") == "true"
+                and not el.get_text(strip=True)
+            ]
+            if not placeholders:
+                return html
+
+            export_tables: dict[str, Tag] = {}
+            export_soup = BeautifulSoup(self.page.body_export or "", "html.parser")
+            for table in export_soup.find_all("table", class_="metadata-summary-macro"):
+                cql = table.get("data-cql") if isinstance(table, Tag) else None
+                if isinstance(cql, str) and cql:
+                    export_tables.setdefault(_normalize_cql(cql), table)
+
+            for placeholder in placeholders:
+                tables: list[Tag] = []
+                for cql in self._nested_report_cqls(str(placeholder.get("data-macro-id", ""))):
+                    table = export_tables.get(_normalize_cql(cql))
+                    if table is not None:
+                        tables.append(table)
+                if not tables:
+                    continue
+                for table in tables:
+                    placeholder.insert_before(table)
+                placeholder.decompose()
+            return str(soup)
+
+        def _nested_report_cqls(self, macro_id: str) -> list[str]:
+            """Return the CQL of each Page Properties Report nested in an app macro.
+
+            body.storage is parsed with `html.parser` rather than the `xml` parser
+            used elsewhere: storage can contain HTML entities that are undefined in
+            XML (third-party macros emit e.g. `&sbquo;`), which puts lxml into error
+            recovery, where it silently drops unrelated entities such as the `&quot;`
+            wrapping CQL values. That corrupts the CQL and breaks the match below.
+            `html.parser` keeps the namespace prefixes, so both the prefixed and
+            unprefixed tag names are accepted.
+            """
+            if not macro_id or not self.page.body_storage:
+                return []
+
+            soup = BeautifulSoup(self.page.body_storage, "html.parser")
+            for macro in soup.find_all(_AC_MACRO_TAGS):
+                if not isinstance(macro, Tag) or _ac_attr(macro, "macro-id") != macro_id:
+                    continue
+                cqls: list[str] = []
+                for nested in macro.find_all(_AC_MACRO_TAGS):
+                    if not isinstance(nested, Tag) or _ac_attr(nested, "name") != "detailssummary":
+                        continue
+                    for param in nested.find_all(_AC_PARAMETER_TAGS):
+                        if isinstance(param, Tag) and _ac_attr(param, "name") == "cql":
+                            cqls.append(param.get_text())
+                            break
+                return cqls
+            return []
 
         def _extract_include_target_title(self, macro_id: str) -> str | None:
             """Resolve the target page title for an `include` / `excerpt-include` macro.

--- a/docs/features.md
+++ b/docs/features.md
@@ -22,7 +22,7 @@ Exports individual pages, pages with descendants, or entire spaces via the Atlas
 ### Page metadata
 
 - **Page properties**: Page Properties macro exported as YAML front matter, [Dataview](https://blacksmithgu.github.io/obsidian-dataview/) inline fields, or [Meta Bind](https://www.moritzjung.dev/obsidian-meta-bind-plugin-docs/) VIEW fields; duplicate keys are disambiguated automatically (configurable via [`export.page_properties_format`](./configuration/options.md#exportpage_properties_format))
-- **Page Properties Report**: dynamic cross-page property tables exported as a static snapshot or a live [Dataview](https://blacksmithgu.github.io/obsidian-dataview/) DQL query (configurable via [`export.page_properties_report_format`](./configuration/options.md#exportpage_properties_report_format))
+- **Page Properties Report**: dynamic cross-page property tables exported as a static snapshot or a live [Dataview](https://blacksmithgu.github.io/obsidian-dataview/) DQL query (configurable via [`export.page_properties_report_format`](./configuration/options.md#exportpage_properties_report_format)). Reports nested inside a third-party app macro (for example [Table Filter](https://marketplace.atlassian.com/apps/27447/table-filter-charts-spreadsheets-for-confluence)) are also exported. Note that such apps apply their filtering, sorting and column hiding in the browser, and that behaviour is not available through the API, so the export contains the full unfiltered report.
 - **Page labels**: exported as `tags` in YAML front matter
 
 ### Diagrams & add-ons

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -2321,6 +2321,16 @@ class TestAppMacroNestedPagePropertiesReport:
         assert "metadata-summary-macro" not in result
         assert "ap-container" in result
 
+    def test_spliced_report_supports_dataview_format(self) -> None:
+        """The splice must not bypass `export.page_properties_report_format`."""
+        converter = self._converter(self._BODY_EXPORT, self._STORAGE)
+        html = converter._inline_app_macro_bodies(self._PLACEHOLDER)
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.page_properties_report_format = "dataview"
+            result = converter.convert(html)
+        assert "```dataview" in result
+        assert "#tool-validation" in result
+
     def test_unresolvable_report_is_warned_about(self, caplog: pytest.LogCaptureFixture) -> None:
         """A report that exists in storage but not in export_view must not vanish quietly."""
         with caplog.at_level(logging.WARNING):

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -2193,3 +2193,200 @@ class TestColumnLayoutConversion:
         assert result.count("Inner Y") == 1
         assert result.count("Outer A") == 1
         assert result.count("Outer B") == 1
+
+
+class TestAppMacroNestedPagePropertiesReport:
+    """Reports nested in third-party Connect app macros are recovered from body.export_view.
+
+    Confluence does not server-render an app macro's body into ``body.view``, so a Page
+    Properties Report wrapped in e.g. StiltSoft Table Filter would otherwise be missing
+    from the export entirely. See issue #281.
+    """
+
+    _CQL = 'label = "tool-validation" and parent = "42"'
+    _CQL_B = 'label = "other" and parent = "42"'
+
+    # Mirrors the real body.view placeholder: the iframe bootstrap <script> is always
+    # present, so an "is the body empty" check must ignore script/style text.
+    _PLACEHOLDER = (
+        '<div class="ap-container conf-macro output-block"'
+        ' data-macro-name="table-filter" data-macro-id="MACRO-1"'
+        ' data-hasbody="true">'
+        '<div class="ap-content"> </div>'
+        '<script class="ap-iframe-body-script">//<![CDATA[\n'
+        '(function(){var data = {"addon_key":"com.stiltsoft.confluence.plugin.'
+        'tablefilter.tablefilter","key":"table-filter",'
+        '"moduleType":"dynamicContentMacros","macro.truncated":"true"};})();\n'
+        "//]]></script>"
+        "</div>"
+    )
+
+    _STORAGE = (
+        '<ac:structured-macro ac:name="table-filter" ac:macro-id="MACRO-1">'
+        '<ac:parameter ac:name="hidelabels">false</ac:parameter>'
+        "<ac:rich-text-body>"
+        '<ac:structured-macro ac:name="detailssummary" ac:macro-id="INNER-1">'
+        f'<ac:parameter ac:name="cql">{_CQL}</ac:parameter>'
+        '<ac:parameter ac:name="headings">Tool Version,Approved for Use</ac:parameter>'
+        "</ac:structured-macro>"
+        "</ac:rich-text-body>"
+        "</ac:structured-macro>"
+    )
+
+    _BODY_EXPORT = (
+        '<table class="aui metadata-summary-macro null"'
+        f" data-cql='{_CQL}'"
+        ' data-current-space-key="TS"'
+        ' data-headings="Tool Version,Approved for Use"'
+        ' data-sort-by="Title"'
+        ' data-reverse-sort="false">'
+        "<tr><th>Title</th><th>Tool Version</th><th>Approved for Use</th></tr>"
+        "<tr><td>Page A</td><td>1.0</td><td>Yes</td></tr>"
+        "</table>"
+    )
+
+    class _MockPage:
+        def __init__(self, body_export: str = "", body_storage: str = "") -> None:
+            self.id = 42
+            self.title = "Test Page"
+            self.base_url = "https://confluence.example.com"
+            self.html = ""
+            self.labels: list = []
+            self.ancestors: list = []
+            self.body_export = body_export
+            self.body_storage = body_storage
+            self.export_path = Path("Test Space/Test Page/Test Page.md")
+
+        def get_attachment_by_file_id(self, file_id: str) -> None:
+            return None
+
+    def _converter(self, body_export: str = "", body_storage: str = "") -> Page.Converter:
+        page = self._MockPage(body_export=body_export, body_storage=body_storage)
+        return Page.Converter(page)
+
+    def test_placeholder_is_replaced_with_report_table(self) -> None:
+        converter = self._converter(self._BODY_EXPORT, self._STORAGE)
+        result = converter._inline_app_macro_bodies(self._PLACEHOLDER)
+        assert "metadata-summary-macro" in result
+        assert "ap-container" not in result
+
+    def test_nested_report_reaches_markdown_output(self) -> None:
+        converter = self._converter(self._BODY_EXPORT, self._STORAGE)
+        html = converter._inline_app_macro_bodies(self._PLACEHOLDER)
+        client = MagicMock()
+        client.get.side_effect = HTTPError("404 Client Error")
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.get_thread_confluence",
+                return_value=client,
+            ),
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
+            s.export.page_properties_report_format = "frozen"
+            result = converter.convert(html)
+        assert "Page A" in result
+        assert "Tool Version" in result
+
+    def test_html_without_app_macro_is_unchanged(self) -> None:
+        converter = self._converter(self._BODY_EXPORT, self._STORAGE)
+        html = "<p>Nothing to see</p>"
+        assert converter._inline_app_macro_bodies(html) == html
+
+    def test_app_macro_with_rendered_body_is_left_alone(self) -> None:
+        """Server-rendered app macro content must not be discarded."""
+        html = (
+            '<div class="ap-container" data-macro-name="other" '
+            'data-macro-id="MACRO-1" data-hasbody="true">Rendered content</div>'
+        )
+        converter = self._converter(self._BODY_EXPORT, self._STORAGE)
+        assert "Rendered content" in converter._inline_app_macro_bodies(html)
+
+    def test_unknown_macro_id_does_not_crash(self) -> None:
+        html = self._PLACEHOLDER.replace("MACRO-1", "MISSING")
+        converter = self._converter(self._BODY_EXPORT, self._STORAGE)
+        result = converter._inline_app_macro_bodies(html)
+        assert "metadata-summary-macro" not in result
+
+    def test_cql_absent_from_export_view_does_not_crash(self) -> None:
+        converter = self._converter("", self._STORAGE)
+        result = converter._inline_app_macro_bodies(self._PLACEHOLDER)
+        assert "metadata-summary-macro" not in result
+
+    def test_missing_storage_does_not_crash(self) -> None:
+        converter = self._converter(self._BODY_EXPORT, "")
+        result = converter._inline_app_macro_bodies(self._PLACEHOLDER)
+        assert "metadata-summary-macro" not in result
+
+    def test_two_reports_in_one_wrapper_are_both_emitted_in_order(self) -> None:
+        storage = (
+            '<ac:structured-macro ac:name="table-filter" ac:macro-id="MACRO-1">'
+            "<ac:rich-text-body>"
+            '<ac:structured-macro ac:name="detailssummary" ac:macro-id="I1">'
+            f'<ac:parameter ac:name="cql">{self._CQL}</ac:parameter>'
+            "</ac:structured-macro>"
+            '<ac:structured-macro ac:name="detailssummary" ac:macro-id="I2">'
+            f'<ac:parameter ac:name="cql">{self._CQL_B}</ac:parameter>'
+            "</ac:structured-macro>"
+            "</ac:rich-text-body>"
+            "</ac:structured-macro>"
+        )
+        body_export = self._BODY_EXPORT + (
+            '<table class="aui metadata-summary-macro null"'
+            f" data-cql='{self._CQL_B}'>"
+            "<tr><th>Title</th></tr><tr><td>Page B</td></tr>"
+            "</table>"
+        )
+        converter = self._converter(body_export, storage)
+        result = converter._inline_app_macro_bodies(self._PLACEHOLDER)
+        assert result.index("Page A") < result.index("Page B")
+
+    def test_cql_quotes_survive_xml_undefined_entities_in_storage(self) -> None:
+        """Storage entities undefined in XML must not corrupt the CQL join key.
+
+        Third-party macros emit HTML entities such as `&sbquo;` in their parameters.
+        Those are undefined in XML, so lxml's XML parser enters error recovery and
+        silently drops unrelated entities elsewhere in the document, including the
+        `&quot;` around CQL values. That produced a key that never matched.
+        """
+        storage = (
+            '<ac:structured-macro ac:name="table-filter" ac:macro-id="MACRO-1">'
+            '<ac:parameter ac:name="labels">Area&sbquo;Brand&sbquo;Country</ac:parameter>'
+            "<ac:rich-text-body>"
+            '<ac:structured-macro ac:name="detailssummary" ac:macro-id="INNER-1">'
+            '<ac:parameter ac:name="cql">label = &quot;tool-validation&quot;'
+            " and parent = &quot;42&quot;</ac:parameter>"
+            "</ac:structured-macro>"
+            "</ac:rich-text-body>"
+            "</ac:structured-macro>"
+        )
+        converter = self._converter(self._BODY_EXPORT, storage)
+        assert converter._nested_report_cqls("MACRO-1") == [self._CQL]
+        result = converter._inline_app_macro_bodies(self._PLACEHOLDER)
+        assert "Page A" in result
+
+    def test_cql_whitespace_differences_still_match(self) -> None:
+        storage = self._STORAGE.replace(self._CQL, 'label = "tool-validation"\n  and parent = "42"')
+        converter = self._converter(self._BODY_EXPORT, storage)
+        assert "Page A" in converter._inline_app_macro_bodies(self._PLACEHOLDER)
+
+    def test_markdown_property_applies_the_preprocessing(self) -> None:
+        """The pass must be wired into the conversion entry point, not just available."""
+        page = self._MockPage(body_export=self._BODY_EXPORT, body_storage=self._STORAGE)
+        page.html = self._PLACEHOLDER
+        converter = Page.Converter(page)
+        client = MagicMock()
+        client.get.side_effect = HTTPError("404 Client Error")
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.get_thread_confluence",
+                return_value=client,
+            ),
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
+            s.export.page_properties_report_format = "frozen"
+            s.export.page_breadcrumbs = False
+            s.export.include_document_title = False
+            s.export.page_metadata_in_frontmatter = False
+            s.export.confluence_url_in_frontmatter = "none"
+            result = converter.markdown
+        assert "Page A" in result

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import types
 from pathlib import Path
 from types import SimpleNamespace
@@ -2320,6 +2321,28 @@ class TestAppMacroNestedPagePropertiesReport:
         assert "metadata-summary-macro" not in result
         assert "ap-container" in result
 
+    def test_unresolvable_report_is_warned_about(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A report that exists in storage but not in export_view must not vanish quietly."""
+        with caplog.at_level(logging.WARNING):
+            self._converter("", self._STORAGE)._inline_app_macro_bodies(self._PLACEHOLDER)
+        assert "has no matching table in body.export_view" in caplog.text
+
+    def test_warning_does_not_contain_raw_cql(self, caplog: pytest.LogCaptureFixture) -> None:
+        """CQL is macro configuration and can embed labels or free-text filters."""
+        with caplog.at_level(logging.WARNING):
+            self._converter("", self._STORAGE)._inline_app_macro_bodies(self._PLACEHOLDER)
+        assert "tool-validation" not in caplog.text
+
+    def test_app_macro_without_a_report_logs_only_at_debug(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Most app macros wrap no report at all; that must not produce a warning."""
+        html = self._PLACEHOLDER.replace("MACRO-1", "MISSING")
+        with caplog.at_level(logging.DEBUG):
+            self._converter(self._BODY_EXPORT, self._STORAGE)._inline_app_macro_bodies(html)
+        assert "has no nested Page Properties Report" in caplog.text
+        assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
     def test_same_report_in_two_placeholders_is_emitted_twice(self) -> None:
         """Inserting a live node moves it, so each placeholder needs its own copy."""
         html = self._PLACEHOLDER + self._PLACEHOLDER.replace("MACRO-1", "MACRO-2")
@@ -2339,9 +2362,7 @@ class TestAppMacroNestedPagePropertiesReport:
         """
         html = (
             '<div class="ap-container" data-macro-name="outer"'
-            ' data-macro-id="MACRO-OUTER" data-hasbody="true">'
-            + self._PLACEHOLDER
-            + "</div>"
+            ' data-macro-id="MACRO-OUTER" data-hasbody="true">' + self._PLACEHOLDER + "</div>"
         )
         storage = self._STORAGE + self._STORAGE.replace("MACRO-1", "MACRO-OUTER").replace(
             "INNER-1", "INNER-OUTER"

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -2306,16 +2306,50 @@ class TestAppMacroNestedPagePropertiesReport:
         converter = self._converter(self._BODY_EXPORT, self._STORAGE)
         result = converter._inline_app_macro_bodies(html)
         assert "metadata-summary-macro" not in result
+        assert "ap-container" in result
 
     def test_cql_absent_from_export_view_does_not_crash(self) -> None:
         converter = self._converter("", self._STORAGE)
         result = converter._inline_app_macro_bodies(self._PLACEHOLDER)
         assert "metadata-summary-macro" not in result
+        assert "ap-container" in result
 
     def test_missing_storage_does_not_crash(self) -> None:
         converter = self._converter(self._BODY_EXPORT, "")
         result = converter._inline_app_macro_bodies(self._PLACEHOLDER)
         assert "metadata-summary-macro" not in result
+        assert "ap-container" in result
+
+    def test_same_report_in_two_placeholders_is_emitted_twice(self) -> None:
+        """Inserting a live node moves it, so each placeholder needs its own copy."""
+        html = self._PLACEHOLDER + self._PLACEHOLDER.replace("MACRO-1", "MACRO-2")
+        storage = self._STORAGE + self._STORAGE.replace("MACRO-1", "MACRO-2").replace(
+            "INNER-1", "INNER-2"
+        )
+        converter = self._converter(self._BODY_EXPORT, storage)
+        result = converter._inline_app_macro_bodies(html)
+        assert result.count("Page A") == 2
+        assert "ap-container" not in result
+
+    def test_nested_app_macro_placeholders_do_not_crash(self) -> None:
+        """Decomposing an outer placeholder orphans the inner one; that must not raise.
+
+        The outer macro must itself resolve to a table, otherwise it is skipped
+        before `decompose()` and the orphaning never happens.
+        """
+        html = (
+            '<div class="ap-container" data-macro-name="outer"'
+            ' data-macro-id="MACRO-OUTER" data-hasbody="true">'
+            + self._PLACEHOLDER
+            + "</div>"
+        )
+        storage = self._STORAGE + self._STORAGE.replace("MACRO-1", "MACRO-OUTER").replace(
+            "INNER-1", "INNER-OUTER"
+        )
+        converter = self._converter(self._BODY_EXPORT, storage)
+        result = converter._inline_app_macro_bodies(html)
+        assert "Page A" in result
+        assert "ap-container" not in result
 
     def test_two_reports_in_one_wrapper_are_both_emitted_in_order(self) -> None:
         storage = (


### PR DESCRIPTION
## Summary

Closes #281.

A Page Properties Report that exports correctly on its own produced **no table at all** once it was nested inside a third-party Connect app macro such as StiltSoft Table Filter — silently, with no warning.

Confluence does not server-render the body of a Connect `dynamicContentMacros` app macro into `body.view`. It emits only an empty placeholder plus an iframe bootstrap script:

```html
<div class="ap-container conf-macro output-block"
     data-macro-name="table-filter" data-macro-id="..." data-hasbody="true">
  <div class="ap-content"> </div>
  <script class="ap-iframe-body-script">...</script>
</div>
```

The nested report survives there only as a **truncated** string inside that script's JSON options (alongside `"macro.truncated": "true"`), so it cannot be recovered from `body.view`. The `<table class="metadata-summary-macro">` element simply never exists in the converter's input, so `convert_table` never dispatches to `convert_page_properties_report`. Nothing was dropping the table; it was never there. That is also why the failure was silent — the existing `return ""` guards were never reached.

`body.export_view` does render the report fully, with the app macro wrapper stripped and every attribute the existing code path needs still intact (`data-cql`, `data-headings`, `data-sort-by`, `data-current-space-key`).

So this is a **routing problem, not a conversion problem**. The fix is one preprocessing pass, `_inline_app_macro_bodies`, added alongside the existing `_strip_excerpt_include_panel_titles` pass in `Converter.markdown`. It replaces each empty `ap-container` placeholder with the matching report table from `body.export_view`, after which all existing handling applies unchanged — including the full-pagination fetch from #277, and the `dataview` output format.

Matching is done on the CQL of the nested `detailssummary` macro in `body.storage`, because `body.export_view` contains no `data-macro-id` or `data-macro-name` attributes at all, leaving the CQL as the only reliable join key.

Keying on `ap-container` rather than on the literal name `table-filter` means other third-party wrappers (Table Excerpt, Chart from Table, and similar) are covered at no extra cost.

### A parser detail worth flagging

`_nested_report_cqls` parses `body.storage` with `html.parser` rather than the `xml` parser used elsewhere in this file.

Confluence storage can contain HTML entities that are **undefined in XML** — third-party macro parameters emit e.g. `&sbquo;`. Those put lxml into error recovery, where it silently drops *unrelated* entities elsewhere in the same document, including the `&quot;` wrapping CQL values. The result is a CQL like `label = my-label and ...` instead of `label = "my-label" and ...`, so the join key never matches.

This cost me a debugging cycle, and it is worth being aware of: the same fragility applies in principle to the other `xml`-parser storage lookups in this file (`_storage_plantuml_macros`, `_extract_include_target_title`, `_extract_uml_from_editor2`). I have deliberately **not** changed those here to keep this PR scoped, but I am happy to open a follow-up issue if you would like them hardened too.

### Logging behaviour

Because the original bug's defining trait was that content vanished with **nothing logged**, the failure paths here are explicit:

- A report present in `body.storage` but with no matching table in `body.export_view` logs a **warning** and is omitted.
- Multiple reports sharing an identical CQL log a **warning** (only the first rendered table can be indexed, since `export_view` has no macro IDs).
- An app macro that wraps no report at all logs at **debug** only. Most app macros legitimately have no report inside them, so warning here would be pure noise.

The CQL string itself is deliberately kept out of warning-level messages and logged at debug instead. It is macro configuration and can embed labels or free-text filters, and every other warning in this module logs metadata only, never a macro's parameter values.

### Known limitations

- Table Filter applies its filtering, sorting and column hiding **client-side** inside the app iframe, and none of that is represented in the REST data. The export is therefore the full, unfiltered report rather than the filtered view seen in the browser. This is documented in `docs/features.md`.
- Static content (for example a plain `<table>`) inside an app macro is still not recovered, since there is no join key available for it. Out of scope here.

## Test Plan

`uv run pytest` — **459 passed** (442 before this change, 17 new). `uv run ruff check` clean.

New test class `TestAppMacroNestedPagePropertiesReport` covers:

- placeholder replaced with the report table, and the report reaching the Markdown output
- the pass being wired into `Converter.markdown`, not merely available
- HTML without an app macro returned unchanged
- an app macro that **did** render content server-side being left alone, so nothing is discarded
- unknown macro id, CQL absent from `body.export_view`, and missing `body.storage` all degrading quietly instead of crashing
- two reports inside one wrapper, both emitted in document order
- the same report referenced by two placeholders being emitted twice
- nested `ap-container` placeholders not crashing the export
- the logging contract above: warning on an unresolvable report, debug-only for an app macro with no report, and no raw CQL at warning level
- `export.page_properties_report_format = "dataview"` still applying to a spliced report
- **regression test for the entity issue above** — storage containing `&sbquo;` alongside `&quot;`-wrapped CQL

The five tests that pin a specific defect — the entity corruption, the shared-table copy, the nested-placeholder crash, and the two logging assertions — were each checked by reverting the corresponding fix and confirming the test fails, so they do not pass vacuously.

Fixtures include the iframe bootstrap `<script>` that the real placeholder always carries. An earlier fixture that omitted it passed while the real page still failed, which is worth mentioning because it is the trap this whole area invites.

Verified end-to-end against a real Confluence Cloud page with a Page Properties Report nested in a Table Filter macro: the table is absent before the change and fully exported after it, with **35 data rows** — more than the 30-row `body.export_view` snapshot, confirming the pagination path runs rather than the truncated snapshot. No leftover placeholder markup, no warnings emitted.

### Review history

This branch went through two review passes. The first found two real defects, both since fixed and covered by the tests above:

- `insert_before` **moves** a node rather than copying it, so a table referenced by two placeholders was silently lost — now inserts a copy.
- Placeholders are collected before the mutation loop, so a nested `ap-container` crashed the whole export once the outer one was decomposed — now guarded.

The second pass found no defects; it produced the logging refinements described above.
