### PR TITLE
fix: render content-tree (page-tree) macro as nested page links

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1984,6 +1984,10 @@ class Page(Document):
                 return ""
 
             max_depth = self._pagetree_depth(params)
+            if max_depth is None and str(el.get("data-macro-name", "")) == "children":
+                # The Children Display macro shows only direct children unless `all=true`.
+                if params.get("all", "").strip().lower() != "true":
+                    max_depth = 1
             lines = self._render_pagetree(root_page.id, root_page.descendants, max_depth)
             if not lines:
                 return ""
@@ -2006,29 +2010,42 @@ class Page(Document):
 
             macro_id = el.get("data-macro-id")
             soup = BeautifulSoup(f"<root>{source}</root>", "xml")
+            found_any = False
             for macro in soup.find_all("structured-macro"):
                 if not isinstance(macro, Tag):
                     continue
                 if macro.get("name") not in self._PAGETREE_MACRO_NAMES:
                     continue
+                found_any = True
                 if macro_id and macro.get("macro-id") != macro_id:
                     continue
-                params: dict[str, str] = {}
-                for p in macro.find_all("parameter", recursive=False):
-                    if not isinstance(p, Tag):
-                        continue
-                    name = p.get("name")
-                    if not name:
-                        continue
-                    # Page-reference params (e.g. `root`) carry their value in a nested
-                    # `ri:page` `ri:content-title` attribute rather than as element text.
-                    ri_page = p.find("page")
-                    if isinstance(ri_page, Tag) and ri_page.get("content-title"):
-                        params[str(name)] = str(ri_page.get("content-title"))
-                    else:
-                        params[str(name)] = p.get_text(strip=True)
-                return params
+                return self._read_macro_params(macro)
+            if macro_id and found_any:
+                logger.warning(
+                    "Content tree macro (macro-id '%s') not found in storage XML; "
+                    "falling back to defaults.",
+                    macro_id,
+                )
             return {}
+
+        @staticmethod
+        def _read_macro_params(macro: Tag) -> dict[str, str]:
+            """Read a structured-macro's direct ``parameter`` children into a dict."""
+            params: dict[str, str] = {}
+            for p in macro.find_all("parameter", recursive=False):
+                if not isinstance(p, Tag):
+                    continue
+                name = p.get("name")
+                if not name:
+                    continue
+                # Page-reference params (e.g. `root`) carry their value in a nested
+                # `ri:page` `ri:content-title` attribute rather than as element text.
+                ri_page = p.find("page")
+                if isinstance(ri_page, Tag) and ri_page.get("content-title"):
+                    params[str(name)] = str(ri_page.get("content-title"))
+                else:
+                    params[str(name)] = p.get_text(strip=True)
+            return params
 
         @staticmethod
         def _pagetree_depth(params: dict[str, str]) -> int | None:
@@ -2101,6 +2118,10 @@ class Page(Document):
             """Build a nested bullet list of page links from the root's descendants."""
             children_by_parent: dict[int, list[Descendant]] = {}
             for descendant in descendants:
+                if not descendant.id:
+                    continue
+                # `Descendant.from_json` strips only the topmost ancestor, so the last
+                # ancestor is the descendant's immediate parent.
                 parent_id = descendant.ancestors[-1].id if descendant.ancestors else root_id
                 children_by_parent.setdefault(parent_id, []).append(descendant)
 

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2018,15 +2018,27 @@ class Page(Document):
                     if not isinstance(p, Tag):
                         continue
                     name = p.get("name")
-                    if name:
+                    if not name:
+                        continue
+                    # Page-reference params (e.g. `root`) carry their value in a nested
+                    # `ri:page` `ri:content-title` attribute rather than as element text.
+                    ri_page = p.find("page")
+                    if isinstance(ri_page, Tag) and ri_page.get("content-title"):
+                        params[str(name)] = str(ri_page.get("content-title"))
+                    else:
                         params[str(name)] = p.get_text(strip=True)
                 return params
             return {}
 
         @staticmethod
         def _pagetree_depth(params: dict[str, str]) -> int | None:
-            """Return the number of levels to render, or ``None`` for the full subtree."""
-            for key in ("startDepth", "depth", "expandDepth"):
+            """Return the number of levels to render, or ``None`` for the full subtree.
+
+            ``depth`` (Children Display macro) expresses the number of levels directly, so
+            it is preferred; ``startDepth`` (Page Tree macro) maps to the same UI "Tree
+            depth" field on the instances observed and is used as a fallback.
+            """
+            for key in ("depth", "expandDepth", "startDepth"):
                 value = params.get(key)
                 if not value:
                     continue
@@ -2065,7 +2077,7 @@ class Page(Document):
         def _find_page_id_by_title(self, title: str) -> int | None:
             """Resolve a page id by title within the current space via CQL (best effort)."""
             client = get_thread_confluence(self.page.base_url)
-            escaped = title.replace('"', '\\"')
+            escaped = title.replace("\\", "\\\\").replace('"', '\\"')
             cql = f'type=page AND space="{self.page.space.key}" AND title="{escaped}"'
             try:
                 response = cast(

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1979,7 +1979,9 @@ class Page(Document):
             the CQL descendants query.
             """
             params = self._extract_pagetree_params(el)
-            root_page = self._resolve_pagetree_root(params.get("root"))
+            root_page = self._resolve_pagetree_root(
+                params.get("root"), params.get("root_space_key")
+            )
             if root_page is None:
                 return ""
 
@@ -2039,10 +2041,14 @@ class Page(Document):
                 if not name:
                     continue
                 # Page-reference params (e.g. `root`) carry their value in a nested
-                # `ri:page` `ri:content-title` attribute rather than as element text.
+                # `ri:page` `ri:content-title` attribute rather than as element text; the
+                # referenced page may live in another space (`ri:space-key`).
                 ri_page = p.find("page")
                 if isinstance(ri_page, Tag) and ri_page.get("content-title"):
                     params[str(name)] = str(ri_page.get("content-title"))
+                    space_key = ri_page.get("space-key")
+                    if space_key:
+                        params[f"{name}_space_key"] = str(space_key)
                 else:
                     params[str(name)] = p.get_text(strip=True)
             return params
@@ -2067,8 +2073,14 @@ class Page(Document):
                     return depth
             return None
 
-        def _resolve_pagetree_root(self, root_value: str | None) -> "Page | None":
-            """Resolve the tree root to a Page (``@self`` / ``@home`` / a page title)."""
+        def _resolve_pagetree_root(
+            self, root_value: str | None, space_key: str | None = None
+        ) -> "Page | None":
+            """Resolve the tree root to a Page (``@self`` / ``@home`` / a page title).
+
+            ``space_key`` is the space of a title-referenced root page (from the macro's
+            ``ri:page`` ``ri:space-key``); when absent the current page's space is used.
+            """
             root = (root_value or "").strip()
             if not root or root == "@self":
                 return self.page
@@ -2083,7 +2095,7 @@ class Page(Document):
                     return None
                 return Page.from_id(homepage_id, self.page.base_url)
 
-            page_id = self._find_page_id_by_title(root)
+            page_id = self._find_page_id_by_title(root, space_key)
             if page_id is None:
                 logger.warning(
                     "Content tree macro root page '%s' could not be resolved; skipping.", root
@@ -2091,11 +2103,15 @@ class Page(Document):
                 return None
             return Page.from_id(page_id, self.page.base_url)
 
-        def _find_page_id_by_title(self, title: str) -> int | None:
-            """Resolve a page id by title within the current space via CQL (best effort)."""
+        def _find_page_id_by_title(self, title: str, space_key: str | None = None) -> int | None:
+            """Resolve a page id by exact title within a space via CQL (best effort)."""
             client = get_thread_confluence(self.page.base_url)
-            escaped = title.replace("\\", "\\\\").replace('"', '\\"')
-            cql = f'type=page AND space="{self.page.space.key}" AND title="{escaped}"'
+            space = space_key or self.page.space.key
+
+            def _escape(value: str) -> str:
+                return value.replace("\\", "\\\\").replace('"', '\\"')
+
+            cql = f'type=page AND space="{_escape(space)}" AND title="{_escape(title)}"'
             try:
                 response = cast(
                     "dict",
@@ -2107,8 +2123,12 @@ class Page(Document):
             results = response.get("results", [])
             if not results:
                 return None
+            # CQL title matching can be fuzzy; require an exact title match to be safe.
+            first = results[0]
+            if first.get("title") != title:
+                return None
             try:
-                return int(results[0].get("id"))
+                return int(first.get("id"))
             except (TypeError, ValueError):
                 return None
 

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1749,6 +1749,9 @@ class Page(Document):
                     "mohamicorp-markdown": self.convert_markdown,
                     "include": self.convert_include,
                     "excerpt-include": self.convert_include,
+                    "content-tree": self.convert_pagetree,
+                    "pagetree": self.convert_pagetree,
+                    "children": self.convert_pagetree,
                 }
                 if macro_name in macro_handlers:
                     return macro_handlers[macro_name](el, text, parent_tags)
@@ -1756,6 +1759,8 @@ class Page(Document):
             class_handlers = {
                 "expand-container": self.convert_expand_container,
                 "columnLayout": self.convert_column_layout,
+                "content-tree": self.convert_pagetree,
+                "plugin_pagetree": self.convert_pagetree,
             }
             for class_name, handler in class_handlers.items():
                 if class_name in str(el.get("class", "")):
@@ -1962,6 +1967,142 @@ class Page(Document):
                 return text
 
             return self.process_tag(tocs[0], parent_tags)
+
+        def convert_pagetree(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
+            """Convert a Confluence content-tree / page-tree macro to nested page links.
+
+            The macro renders as an empty JavaScript placeholder in ``body.view``, so its
+            child pages are resolved from the API (``Page.descendants``) and emitted as a
+            nested Markdown bullet list. Honors the ``root`` (``@self`` / ``@home`` / a page
+            title) and tree-depth parameters read from the storage-format XML. Children are
+            ordered by title, since Confluence's manual "position" order is not available via
+            the CQL descendants query.
+            """
+            params = self._extract_pagetree_params(el)
+            root_page = self._resolve_pagetree_root(params.get("root"))
+            if root_page is None:
+                return ""
+
+            max_depth = self._pagetree_depth(params)
+            lines = self._render_pagetree(root_page.id, root_page.descendants, max_depth)
+            if not lines:
+                return ""
+            return "\n" + "\n".join(lines) + "\n\n"
+
+        _PAGETREE_MACRO_NAMES: ClassVar[set[str]] = {"content-tree", "pagetree", "children"}
+
+        def _extract_pagetree_params(self, el: BeautifulSoup) -> dict[str, str]:
+            """Read the content-tree macro parameters from the storage-format XML.
+
+            BeautifulSoup with the ``xml`` parser strips namespace prefixes, so
+            ``ac:structured-macro`` becomes ``structured-macro`` and ``ac:parameter``
+            becomes ``parameter``. The macro is matched by ``macro-id`` when the rendered
+            div carries one; otherwise the first matching macro is used (class-triggered
+            fallback path).
+            """
+            source = self.page.editor2 or self.page.body_storage
+            if not source:
+                return {}
+
+            macro_id = el.get("data-macro-id")
+            soup = BeautifulSoup(f"<root>{source}</root>", "xml")
+            for macro in soup.find_all("structured-macro"):
+                if not isinstance(macro, Tag):
+                    continue
+                if macro.get("name") not in self._PAGETREE_MACRO_NAMES:
+                    continue
+                if macro_id and macro.get("macro-id") != macro_id:
+                    continue
+                params: dict[str, str] = {}
+                for p in macro.find_all("parameter", recursive=False):
+                    if not isinstance(p, Tag):
+                        continue
+                    name = p.get("name")
+                    if name:
+                        params[str(name)] = p.get_text(strip=True)
+                return params
+            return {}
+
+        @staticmethod
+        def _pagetree_depth(params: dict[str, str]) -> int | None:
+            """Return the number of levels to render, or ``None`` for the full subtree."""
+            for key in ("startDepth", "depth", "expandDepth"):
+                value = params.get(key)
+                if not value:
+                    continue
+                try:
+                    depth = int(value)
+                except ValueError:
+                    continue
+                if depth > 0:
+                    return depth
+            return None
+
+        def _resolve_pagetree_root(self, root_value: str | None) -> "Page | None":
+            """Resolve the tree root to a Page (``@self`` / ``@home`` / a page title)."""
+            root = (root_value or "").strip()
+            if not root or root == "@self":
+                return self.page
+            if root == "@home":
+                homepage_id = self.page.space.homepage
+                if not homepage_id:
+                    logger.warning(
+                        "Content tree macro root is @home but space '%s' has no homepage; "
+                        "skipping.",
+                        self.page.space.key,
+                    )
+                    return None
+                return Page.from_id(homepage_id, self.page.base_url)
+
+            page_id = self._find_page_id_by_title(root)
+            if page_id is None:
+                logger.warning(
+                    "Content tree macro root page '%s' could not be resolved; skipping.", root
+                )
+                return None
+            return Page.from_id(page_id, self.page.base_url)
+
+        def _find_page_id_by_title(self, title: str) -> int | None:
+            """Resolve a page id by title within the current space via CQL (best effort)."""
+            client = get_thread_confluence(self.page.base_url)
+            escaped = title.replace('"', '\\"')
+            cql = f'type=page AND space="{self.page.space.key}" AND title="{escaped}"'
+            try:
+                response = cast(
+                    "dict",
+                    client.get("rest/api/content/search", params={"cql": cql, "limit": 1}),
+                )
+            except Exception:
+                logger.exception("Failed to resolve content tree root page '%s'.", title)
+                return None
+            results = response.get("results", [])
+            if not results:
+                return None
+            try:
+                return int(results[0].get("id"))
+            except (TypeError, ValueError):
+                return None
+
+        def _render_pagetree(
+            self, root_id: int, descendants: list["Descendant"], max_depth: int | None
+        ) -> list[str]:
+            """Build a nested bullet list of page links from the root's descendants."""
+            children_by_parent: dict[int, list[Descendant]] = {}
+            for descendant in descendants:
+                parent_id = descendant.ancestors[-1].id if descendant.ancestors else root_id
+                children_by_parent.setdefault(parent_id, []).append(descendant)
+
+            lines: list[str] = []
+
+            def walk(parent_id: int, level: int) -> None:
+                if max_depth is not None and level >= max_depth:
+                    return
+                for child in sorted(children_by_parent.get(parent_id, []), key=lambda c: c.title):
+                    lines.append(f"{'  ' * level}- {self.convert_page_link(child.id)}")
+                    walk(child.id, level + 1)
+
+            walk(root_id, 0)
+            return lines
 
         def convert_hidden_content(
             self, el: BeautifulSoup, text: str, parent_tags: list[str]

--- a/tests/unit/test_pagetree_conversion.py
+++ b/tests/unit/test_pagetree_conversion.py
@@ -50,17 +50,21 @@ def _make_page(
     return page
 
 
-def _content_tree_editor2(root: str = "@self", depth: str | None = None) -> str:
+def _content_tree_editor2(
+    root: str = "@self", depth: str | None = None, space_key: str | None = None
+) -> str:
     """Build a page-tree macro in the real storage format.
 
     The `root` value is carried in a nested `ri:page` `ri:content-title` attribute, as
-    Confluence actually stores it (verified against a live page), not as element text.
+    Confluence actually stores it (verified against a live page), not as element text. A
+    cross-space root also carries a `ri:space-key`.
     """
     depth_param = f'<ac:parameter ac:name="startDepth">{depth}</ac:parameter>' if depth else ""
+    space_attr = f' ri:space-key="{space_key}"' if space_key else ""
     return (
         '<ac:structured-macro ac:name="content-tree" ac:macro-id="ct-1">'
         '<ac:parameter ac:name="root">'
-        f'<ac:link><ri:page ri:content-title="{root}" /></ac:link>'
+        f'<ac:link><ri:page ri:content-title="{root}"{space_attr} /></ac:link>'
         "</ac:parameter>"
         f"{depth_param}"
         "</ac:structured-macro>"
@@ -212,6 +216,52 @@ def test_content_tree_unresolvable_title_root_returns_empty(
     mock_client_factory.return_value = client
 
     page = _make_page(_content_tree_editor2(root="Missing Page"), descendants=[])
+    converter = _converter(mock_settings, page)
+
+    assert converter.convert_pagetree(_el(), "", []) == ""
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.get_thread_confluence")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_content_tree_cross_space_root_uses_space_key(
+    mock_settings: MagicMock, mock_client_factory: MagicMock, mock_from_id: MagicMock
+) -> None:
+    client = MagicMock()
+    client.get.return_value = {"results": [{"id": 300, "title": "Other Root"}]}
+    mock_client_factory.return_value = client
+
+    other_root = _make_page("", descendants=[_descendant(5, "Other Child", [300])])
+    other_root.id = 300
+
+    def _from_id(page_id: int, _base_url: str) -> MagicMock:
+        if page_id == 300:
+            return other_root
+        return _linked_page(page_id, {5: "Other Child"}.get(page_id, "Unknown"))
+
+    mock_from_id.side_effect = _from_id
+    page = _make_page(_content_tree_editor2(root="Other Root", space_key="OTHER"), descendants=[])
+    converter = _converter(mock_settings, page)
+
+    result = converter.convert_pagetree(_el(), "", [])
+
+    assert result == "\n- [[Other Child]]\n\n"
+    # The CQL lookup targets the referenced space, not the current page's space.
+    cql = client.get.call_args.kwargs["params"]["cql"]
+    assert 'space="OTHER"' in cql
+
+
+@patch("confluence_markdown_exporter.confluence.get_thread_confluence")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_content_tree_title_mismatch_returns_empty(
+    mock_settings: MagicMock, mock_client_factory: MagicMock
+) -> None:
+    # CQL returns a fuzzy match with a different title; it must be rejected.
+    client = MagicMock()
+    client.get.return_value = {"results": [{"id": 7, "title": "Design Notes"}]}
+    mock_client_factory.return_value = client
+
+    page = _make_page(_content_tree_editor2(root="Design"), descendants=[])
     converter = _converter(mock_settings, page)
 
     assert converter.convert_pagetree(_el(), "", []) == ""

--- a/tests/unit/test_pagetree_conversion.py
+++ b/tests/unit/test_pagetree_conversion.py
@@ -1,0 +1,199 @@
+"""Unit tests for the content-tree / page-tree macro conversion."""
+
+from collections.abc import Callable
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from bs4 import BeautifulSoup
+
+from confluence_markdown_exporter.confluence import Page
+from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
+
+BASE_URL = "https://example.atlassian.net/wiki"
+
+
+def _ancestor(page_id: int) -> MagicMock:
+    anc = MagicMock()
+    anc.id = page_id
+    return anc
+
+
+def _descendant(page_id: int, title: str, ancestors: list[int]) -> MagicMock:
+    desc = MagicMock()
+    desc.id = page_id
+    desc.title = title
+    desc.ancestors = [_ancestor(a) for a in ancestors]
+    return desc
+
+
+def _make_page(
+    editor2: str,
+    descendants: list[MagicMock] | None = None,
+    homepage: int | None = None,
+) -> MagicMock:
+    page = MagicMock(spec=Page)
+    page.id = 100
+    page.title = "Root Page"
+    page.html = "<h1>Root Page</h1>"
+    page.labels = []
+    page.ancestors = []
+    page.attachments = []
+    page.editor2 = editor2
+    page.body_storage = ""
+    page.base_url = BASE_URL
+    page.descendants = descendants or []
+    page.space = MagicMock()
+    page.space.key = "TEST"
+    page.space.homepage = homepage
+    return page
+
+
+def _content_tree_editor2(root: str = "@self", depth: str | None = None) -> str:
+    depth_param = f'<ac:parameter ac:name="startDepth">{depth}</ac:parameter>' if depth else ""
+    return (
+        '<ac:structured-macro ac:name="content-tree" ac:macro-id="ct-1">'
+        f'<ac:parameter ac:name="root">{root}</ac:parameter>'
+        f"{depth_param}"
+        "</ac:structured-macro>"
+    )
+
+
+CT_DIV = '<div data-macro-name="content-tree" data-macro-id="ct-1"></div>'
+
+
+def _linked_page(page_id: int, title: str) -> MagicMock:
+    page = MagicMock(spec=Page)
+    page.id = page_id
+    page.title = title
+    return page
+
+
+def _from_id_factory(titles: dict[int, str]) -> Callable[[int, str], MagicMock]:
+    def _from_id(page_id: int, _base_url: str) -> MagicMock:
+        return _linked_page(page_id, titles.get(page_id, "Unknown"))
+
+    return _from_id
+
+
+def _converter(mock_settings: MagicMock, page: MagicMock) -> Page.Converter:
+    PageTitleRegistry.reset()
+    mock_settings.export.include_document_title = False
+    mock_settings.export.page_breadcrumbs = False
+    mock_settings.export.page_href = "wiki"
+    return Page.Converter(page)
+
+
+TITLES = {1: "Child A", 2: "Child B", 3: "Grandchild B1"}
+
+
+def _el() -> BeautifulSoup:
+    return BeautifulSoup(CT_DIV, "html.parser").find("div")
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_content_tree_renders_nested_list(
+    mock_settings: MagicMock, mock_from_id: MagicMock
+) -> None:
+    mock_from_id.side_effect = _from_id_factory(TITLES)
+    descendants = [
+        _descendant(1, "Child A", [100]),
+        _descendant(2, "Child B", [100]),
+        _descendant(3, "Grandchild B1", [100, 2]),
+    ]
+    converter = _converter(mock_settings, _make_page(_content_tree_editor2(), descendants))
+
+    result = converter.convert_pagetree(_el(), "", [])
+
+    assert result == "\n- [[Child A]]\n- [[Child B]]\n  - [[Grandchild B1]]\n\n"
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_content_tree_depth_limits_nesting(
+    mock_settings: MagicMock, mock_from_id: MagicMock
+) -> None:
+    mock_from_id.side_effect = _from_id_factory(TITLES)
+    descendants = [
+        _descendant(1, "Child A", [100]),
+        _descendant(2, "Child B", [100]),
+        _descendant(3, "Grandchild B1", [100, 2]),
+    ]
+    converter = _converter(mock_settings, _make_page(_content_tree_editor2(depth="1"), descendants))
+
+    result = converter.convert_pagetree(_el(), "", [])
+
+    assert result == "\n- [[Child A]]\n- [[Child B]]\n\n"
+    assert "Grandchild" not in result
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_content_tree_no_descendants_returns_empty(
+    mock_settings: MagicMock, mock_from_id: MagicMock
+) -> None:
+    mock_from_id.side_effect = _from_id_factory(TITLES)
+    converter = _converter(mock_settings, _make_page(_content_tree_editor2(), []))
+
+    assert converter.convert_pagetree(_el(), "", []) == ""
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_content_tree_root_home_resolves_via_homepage(
+    mock_settings: MagicMock, mock_from_id: MagicMock
+) -> None:
+    homepage_page = _make_page("", descendants=[_descendant(1, "Child A", [200])], homepage=None)
+    homepage_page.id = 200
+
+    def _from_id(page_id: int, _base_url: str) -> MagicMock:
+        if page_id == 200:
+            return homepage_page
+        return _linked_page(page_id, TITLES.get(page_id, "Unknown"))
+
+    mock_from_id.side_effect = _from_id
+    page = _make_page(_content_tree_editor2(root="@home"), descendants=[], homepage=200)
+    converter = _converter(mock_settings, page)
+
+    result = converter.convert_pagetree(_el(), "", [])
+
+    assert result == "\n- [[Child A]]\n\n"
+
+
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_content_tree_root_home_without_homepage_returns_empty(
+    mock_settings: MagicMock,
+) -> None:
+    page = _make_page(_content_tree_editor2(root="@home"), descendants=[], homepage=None)
+    converter = _converter(mock_settings, page)
+
+    assert converter.convert_pagetree(_el(), "", []) == ""
+
+
+@patch("confluence_markdown_exporter.confluence.get_thread_confluence")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_content_tree_unresolvable_title_root_returns_empty(
+    mock_settings: MagicMock, mock_client_factory: MagicMock
+) -> None:
+    client = MagicMock()
+    client.get.return_value = {"results": []}
+    mock_client_factory.return_value = client
+
+    page = _make_page(_content_tree_editor2(root="Missing Page"), descendants=[])
+    converter = _converter(mock_settings, page)
+
+    assert converter.convert_pagetree(_el(), "", []) == ""
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_content_tree_dispatched_via_convert_div(
+    mock_settings: MagicMock, mock_from_id: MagicMock
+) -> None:
+    mock_from_id.side_effect = _from_id_factory(TITLES)
+    descendants = [_descendant(1, "Child A", [100])]
+    converter = _converter(mock_settings, _make_page(_content_tree_editor2(), descendants))
+
+    result = converter.convert_div(_el(), "", [])
+
+    assert result == "\n- [[Child A]]\n\n"

--- a/tests/unit/test_pagetree_conversion.py
+++ b/tests/unit/test_pagetree_conversion.py
@@ -49,10 +49,17 @@ def _make_page(
 
 
 def _content_tree_editor2(root: str = "@self", depth: str | None = None) -> str:
+    """Build a page-tree macro in the real storage format.
+
+    The `root` value is carried in a nested `ri:page` `ri:content-title` attribute, as
+    Confluence actually stores it (verified against a live page), not as element text.
+    """
     depth_param = f'<ac:parameter ac:name="startDepth">{depth}</ac:parameter>' if depth else ""
     return (
         '<ac:structured-macro ac:name="content-tree" ac:macro-id="ct-1">'
-        f'<ac:parameter ac:name="root">{root}</ac:parameter>'
+        '<ac:parameter ac:name="root">'
+        f'<ac:link><ri:page ri:content-title="{root}" /></ac:link>'
+        "</ac:parameter>"
         f"{depth_param}"
         "</ac:structured-macro>"
     )
@@ -195,5 +202,25 @@ def test_content_tree_dispatched_via_convert_div(
     converter = _converter(mock_settings, _make_page(_content_tree_editor2(), descendants))
 
     result = converter.convert_div(_el(), "", [])
+
+    assert result == "\n- [[Child A]]\n\n"
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_content_tree_plaintext_root_falls_back_to_text(
+    mock_settings: MagicMock, mock_from_id: MagicMock
+) -> None:
+    # Some macro variants store `root` as plain element text instead of an ri:page link.
+    mock_from_id.side_effect = _from_id_factory(TITLES)
+    editor2 = (
+        '<ac:structured-macro ac:name="content-tree" ac:macro-id="ct-1">'
+        '<ac:parameter ac:name="root">@self</ac:parameter>'
+        "</ac:structured-macro>"
+    )
+    descendants = [_descendant(1, "Child A", [100])]
+    converter = _converter(mock_settings, _make_page(editor2, descendants))
+
+    result = converter.convert_pagetree(_el(), "", [])
 
     assert result == "\n- [[Child A]]\n\n"

--- a/tests/unit/test_pagetree_conversion.py
+++ b/tests/unit/test_pagetree_conversion.py
@@ -1,9 +1,11 @@
 """Unit tests for the content-tree / page-tree macro conversion."""
 
+import logging
 from collections.abc import Callable
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pytest
 from bs4 import BeautifulSoup
 
 from confluence_markdown_exporter.confluence import Page
@@ -66,6 +68,18 @@ def _content_tree_editor2(root: str = "@self", depth: str | None = None) -> str:
 
 
 CT_DIV = '<div data-macro-name="content-tree" data-macro-id="ct-1"></div>'
+CHILDREN_DIV = '<div data-macro-name="children" data-macro-id="ct-1"></div>'
+
+
+def _children_editor2(all_param: str | None = None, depth: str | None = None) -> str:
+    extra = ""
+    if all_param is not None:
+        extra += f'<ac:parameter ac:name="all">{all_param}</ac:parameter>'
+    if depth is not None:
+        extra += f'<ac:parameter ac:name="depth">{depth}</ac:parameter>'
+    return (
+        f'<ac:structured-macro ac:name="children" ac:macro-id="ct-1">{extra}</ac:structured-macro>'
+    )
 
 
 def _linked_page(page_id: int, title: str) -> MagicMock:
@@ -95,6 +109,17 @@ TITLES = {1: "Child A", 2: "Child B", 3: "Grandchild B1"}
 
 def _el() -> BeautifulSoup:
     return BeautifulSoup(CT_DIV, "html.parser").find("div")
+
+
+def _children_el() -> BeautifulSoup:
+    return BeautifulSoup(CHILDREN_DIV, "html.parser").find("div")
+
+
+NESTED_DESCENDANTS = [
+    _descendant(1, "Child A", [100]),
+    _descendant(2, "Child B", [100]),
+    _descendant(3, "Grandchild B1", [100, 2]),
+]
 
 
 @patch("confluence_markdown_exporter.confluence.Page.from_id")
@@ -224,3 +249,92 @@ def test_content_tree_plaintext_root_falls_back_to_text(
     result = converter.convert_pagetree(_el(), "", [])
 
     assert result == "\n- [[Child A]]\n\n"
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_children_macro_defaults_to_direct_children(
+    mock_settings: MagicMock, mock_from_id: MagicMock
+) -> None:
+    mock_from_id.side_effect = _from_id_factory(TITLES)
+    converter = _converter(mock_settings, _make_page(_children_editor2(), NESTED_DESCENDANTS))
+
+    result = converter.convert_pagetree(_children_el(), "", [])
+
+    assert result == "\n- [[Child A]]\n- [[Child B]]\n\n"
+    assert "Grandchild" not in result
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_children_macro_all_true_renders_full_tree(
+    mock_settings: MagicMock, mock_from_id: MagicMock
+) -> None:
+    mock_from_id.side_effect = _from_id_factory(TITLES)
+    converter = _converter(
+        mock_settings, _make_page(_children_editor2(all_param="true"), NESTED_DESCENDANTS)
+    )
+
+    result = converter.convert_pagetree(_children_el(), "", [])
+
+    assert result == "\n- [[Child A]]\n- [[Child B]]\n  - [[Grandchild B1]]\n\n"
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_children_macro_explicit_depth_overrides_default(
+    mock_settings: MagicMock, mock_from_id: MagicMock
+) -> None:
+    mock_from_id.side_effect = _from_id_factory(TITLES)
+    converter = _converter(
+        mock_settings, _make_page(_children_editor2(depth="2"), NESTED_DESCENDANTS)
+    )
+
+    result = converter.convert_pagetree(_children_el(), "", [])
+
+    assert result == "\n- [[Child A]]\n- [[Child B]]\n  - [[Grandchild B1]]\n\n"
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_unmatched_macro_id_warns_and_falls_back(
+    mock_settings: MagicMock,
+    mock_from_id: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_from_id.side_effect = _from_id_factory(TITLES)
+    # Storage macro has a different macro-id than the rendered div's data-macro-id.
+    editor2 = (
+        '<ac:structured-macro ac:name="content-tree" ac:macro-id="other-id">'
+        '<ac:parameter ac:name="root">'
+        '<ac:link><ri:page ri:content-title="@self" /></ac:link>'
+        "</ac:parameter>"
+        "</ac:structured-macro>"
+    )
+    descendants = [_descendant(1, "Child A", [100])]
+    converter = _converter(mock_settings, _make_page(editor2, descendants))
+
+    with caplog.at_level(logging.WARNING):
+        result = converter.convert_pagetree(_el(), "", [])
+
+    # Falls back to defaults (root=@self -> current page) and logs a warning.
+    assert result == "\n- [[Child A]]\n\n"
+    assert any("not found in storage XML" in rec.message for rec in caplog.records)
+
+
+@patch("confluence_markdown_exporter.confluence.Page.from_id")
+@patch("confluence_markdown_exporter.confluence.settings")
+def test_descendant_with_zero_id_is_skipped(
+    mock_settings: MagicMock, mock_from_id: MagicMock
+) -> None:
+    mock_from_id.side_effect = _from_id_factory(TITLES)
+    descendants = [
+        _descendant(1, "Child A", [100]),
+        _descendant(0, "Broken", [100]),
+    ]
+    converter = _converter(mock_settings, _make_page(_content_tree_editor2(), descendants))
+
+    result = converter.convert_pagetree(_el(), "", [])
+
+    assert result == "\n- [[Child A]]\n\n"
+    assert "Broken" not in result


### PR DESCRIPTION
## What

Adds a handler for the **Content Tree** / **Page Tree** macro (`content-tree`, legacy `pagetree`, and the related `children` / Children Display macro). It resolves the tree's child pages from the API and emits a nested Markdown bullet list of page links.

## Why

The macro renders as an empty JavaScript placeholder in `body.view`, so it was silently dropped during export. Pages that use it as a navigation index exported with an empty body (only the title). See #283.

## How

- New `convert_pagetree` handler, dispatched from `convert_div` by `data-macro-name` (`content-tree`, `pagetree`, `children`) and by CSS class (`content-tree`, `plugin_pagetree`) as a fallback for when the rendered placeholder lacks `data-macro-name`.
- Macro parameters are read from the storage-format XML (`editor2` / `body_storage`), matched by `macro-id` (mirroring the existing `include` macro handling). The `root` value is taken from its nested `ri:page` `ri:content-title` attribute, which is how Confluence actually stores it (verified against a live page), with a fallback to element text for other variants.
- Root resolution: `@self` / empty -> current page; `@home` -> space homepage; a page title -> best-effort CQL lookup. The lookup honors the root reference's `ri:space-key` (so a root in another space resolves correctly), falls back to the current space when absent, escapes backslashes/quotes, and requires an exact title match so a fuzzy CQL hit cannot resolve to the wrong page.
- Depth: `depth` (Children Display) is preferred, then `startDepth` (Page Tree, which maps to the same "Tree depth" UI field on the instances observed). The `children` macro defaults to direct children only unless `all=true` or an explicit depth is set; Content Tree / Page Tree default to the full subtree.
- The tree is built from `Page.descendants`, nested via each node's ancestor chain and limited to the configured depth. Children are ordered by title (Confluence's manual "position" order is not available via the CQL descendants query). Descendants with a missing id are skipped so one malformed node cannot abort the page.
- Links reuse the existing `convert_page_link` helper, so wiki/relative href modes and title disambiguation are handled consistently.

## Tests

New `tests/unit/test_pagetree_conversion.py` covering: nested rendering, depth limiting, `@self` / `@home` roots, missing homepage, unresolvable title root, empty subtree, dispatch via `convert_div`, plain-text vs. `ri:content-title` root, cross-space root resolution, exact-title rejection, the `children` default/`all`/`depth` behavior, the unmatched-`macro-id` warning, and the zero-id descendant guard. Full suite passes (457 tests); lint and format clean.

## Notes

- Verified end-to-end against a live Confluence page: the previously empty page now renders its 15 child pages as links.
- The exact rendered markup (`data-macro-name` vs. CSS class) can vary between Confluence Cloud and Server/DC; detection covers both.

Closes #283.
