### PR TITLE
Fix path in _get_path_for_href (was OS dependent)

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2882,7 +2882,7 @@ class Page(Document):
             elif style == "wiki":
                 result = path.name
             else:
-                result = os.path.relpath(path, self.page.export_path.parent)
+                result = os.path.relpath(path, self.page.export_path.parent).replace(os.sep, "/")
             return result
 
 


### PR DESCRIPTION
Previously, the OS separator was used in relative paths, meaning \ on Windows. This doesn't work for markdown and also results in platform-dependent exports
