### PR TITLE
feat(confluence): export plantumlcloud macro as a code block

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -3,6 +3,7 @@
 https://developer.atlassian.com/cloud/confluence/rest/v1/intro
 """
 
+import base64
 import functools
 import html
 import json
@@ -11,6 +12,7 @@ import mimetypes
 import os
 import re
 import urllib.parse
+import zlib
 from collections.abc import Set
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
@@ -81,6 +83,10 @@ _MAX_UNICODE_CODEPOINT = 0x10FFFF
 
 # Rows requested per call when fetching all Page Properties Report entries.
 _REPORT_FETCH_PAGE_SIZE = 50
+
+# Upper bound for an inflated `plantumlcloud` payload. Deflate reaches ~1000:1, so an
+# unbounded inflate of remote page content could exhaust memory.
+_MAX_PLANTUML_SOURCE_BYTES = 4 * 1024 * 1024
 
 _RE_RGB_BG = re.compile(r"background-color:\s*rgb\((\d+),\s*(\d+),\s*(\d+)\)")
 _RE_RGB_COLOR = re.compile(r"(?<![a-z-])color:\s*rgb\((\d+),\s*(\d+),\s*(\d+)\)")
@@ -1478,7 +1484,8 @@ class Page(Document):
             self._image_captions_cache: dict[str, str] | None = None
             self._panel_icon_map_cache: dict[str, str] | None = None
             self._plantuml_index: int = 0
-            self._storage_plantuml_macros_cache: list[Tag] | None = None
+            self._plantumlcloud_index: int = 0
+            self._storage_macros_cache: dict[str, list[Tag]] = {}
 
         @property
         def _colorid_map(self) -> dict[str, str]:
@@ -1494,10 +1501,9 @@ class Page(Document):
                 self._colorid_map_cache = cache
             return self._colorid_map_cache
 
-        @property
-        def _storage_plantuml_macros(self) -> list[Tag]:
-            """Cache and return all PlantUML structured-macros from body.storage."""
-            if self._storage_plantuml_macros_cache is None:
+        def _storage_macros_by_name(self, name: str) -> list[Tag]:
+            """Cache and return all structured-macros with the given name from body.storage."""
+            if name not in self._storage_macros_cache:
                 macros: list[Tag] = []
                 if self.page.body_storage:
                     wrapped = f"<root>{self.page.body_storage}</root>"
@@ -1505,10 +1511,10 @@ class Page(Document):
                     macros.extend(
                         macro
                         for macro in soup.find_all("structured-macro")
-                        if isinstance(macro, Tag) and macro.get("name") == "plantuml"
+                        if isinstance(macro, Tag) and macro.get("name") == name
                     )
-                self._storage_plantuml_macros_cache = macros
-            return self._storage_plantuml_macros_cache
+                self._storage_macros_cache[name] = macros
+            return self._storage_macros_cache[name]
 
         @property
         def _image_captions(self) -> dict[str, str]:
@@ -1540,14 +1546,21 @@ class Page(Document):
             return self._panel_icon_map_cache
 
         @staticmethod
-        def _extract_panel_emoji(macro: Tag) -> str | None:
-            params: dict[str, str] = {}
-            for p in macro.find_all("parameter", recursive=False):
-                if not isinstance(p, Tag):
-                    continue
-                name = p.get("name")
-                if name:
-                    params[str(name)] = p.get_text(strip=True)
+        def _macro_params(macro: Tag) -> dict[str, str]:
+            """Map a structured-macro's direct `parameter` children to their values.
+
+            Only direct children: a macro body may hold nested macros with parameters of
+            their own. On a repeated name the last occurrence wins.
+            """
+            return {
+                str(p.get("name")): p.get_text(strip=True)
+                for p in macro.find_all("parameter", recursive=False)
+                if isinstance(p, Tag) and p.get("name")
+            }
+
+        @classmethod
+        def _extract_panel_emoji(cls, macro: Tag) -> str | None:
+            params = cls._macro_params(macro)
             if text := params.get("panelIconText"):
                 return text
             if icon_id := params.get("panelIconId"):
@@ -1741,6 +1754,7 @@ class Page(Document):
                     "details": self.convert_page_properties,
                     "drawio": self.convert_drawio,
                     "plantuml": self.convert_plantuml,
+                    "plantumlcloud": self.convert_plantumlcloud,
                     "scroll-ignore": self.convert_hidden_content,
                     "toc": self.convert_toc,
                     "jira": self.convert_jira_table,
@@ -2462,7 +2476,7 @@ class Page(Document):
 
         def _extract_uml_from_storage(self) -> str | None:
             """Extract PlantUML source from body.storage by position (Server format)."""
-            storage_macros = self._storage_plantuml_macros
+            storage_macros = self._storage_macros_by_name("plantuml")
             idx = self._plantuml_index
             self._plantuml_index += 1
             if idx >= len(storage_macros):
@@ -2503,6 +2517,106 @@ class Page(Document):
                 return f"\n```plantuml\n{uml}\n```\n\n"
 
             logger.warning("PlantUML macro could not be resolved from editor2 or body.storage")
+            return "\n<!-- PlantUML diagram (source not found) -->\n\n"
+
+        @staticmethod
+        def _decode_plantumlcloud_data(data: str, *, compressed: bool) -> str | None:
+            """Decode the ``data`` parameter of a ``plantumlcloud`` macro.
+
+            The app stores the diagram source base64-encoded.  When ``compressed`` is
+            set, the payload is additionally raw-deflated (no zlib header).  The text may
+            also be percent-encoded, independently of ``compressed``, so that is detected
+            from the text itself rather than from the parameter.
+
+            Returns ``None`` on any malformed payload so the caller can emit a visible
+            marker; never returns a partially decoded payload.
+            """
+            try:
+                # Not `validate=True`: storage values may be line-wrapped, and rejecting
+                # them here would discard a perfectly decodable diagram.
+                payload = base64.b64decode(data)
+            except ValueError:
+                return None
+
+            if compressed:
+                decompressor = zlib.decompressobj(-zlib.MAX_WBITS)
+                try:
+                    payload = decompressor.decompress(payload, _MAX_PLANTUML_SOURCE_BYTES)
+                except zlib.error:
+                    return None
+                # Not the size guard itself - `max_length` already bounds the inflate, and
+                # the `eof` check below rejects what is left over. This branch only tells
+                # "too large" apart from "truncated" in the log.
+                if decompressor.unconsumed_tail:
+                    logger.warning(
+                        "PlantUML (plantumlcloud) source is larger than %d bytes, skipping it",
+                        _MAX_PLANTUML_SOURCE_BYTES,
+                    )
+                    return None
+                if not decompressor.eof:
+                    # A truncated deflate stream inflates without error, so without this
+                    # check a partial diagram would be exported as if it were complete.
+                    logger.warning("PlantUML (plantumlcloud) payload is truncated, skipping it")
+                    return None
+
+            try:
+                text = payload.decode("utf-8")
+            except UnicodeDecodeError:
+                return None
+
+            # Percent-decode only when the payload actually is encoded: PlantUML sources
+            # use a literal `%` (`%date%`, `%filename()`), which unquote would corrupt.
+            if "@start" not in text:
+                text = unquote(text)
+            return text.strip() or None
+
+        def _extract_uml_from_plantumlcloud(self, macro_id: str | None) -> str | None:
+            """Extract PlantUML source for a `plantumlcloud` macro from body.storage."""
+            macros = self._storage_macros_by_name("plantumlcloud")
+            idx = (
+                next((i for i, m in enumerate(macros) if m.get("macro-id") == macro_id), None)
+                if macro_id
+                else None
+            )
+            if idx is None:
+                if macro_id and all(m.get("macro-id") for m in macros):
+                    # Every stored macro is identifiable, yet none matches: the placeholder
+                    # belongs to another page - an include macro expands the transcluded
+                    # page's view HTML into this one. Falling back to position would emit
+                    # an unrelated diagram, which is worse than none. Storage that carries
+                    # no macro-id at all still falls through to positional matching.
+                    return None
+                idx = self._plantumlcloud_index
+            if idx >= len(macros):
+                return None
+            # Advance the positional cursor past the consumed macro, also on a macro-id
+            # match, so a later macro without a macro-id does not re-resolve this one.
+            self._plantumlcloud_index = max(self._plantumlcloud_index, idx + 1)
+
+            params = self._macro_params(macros[idx])
+            data = params.get("data")
+            if not data:
+                return None
+            compressed = params.get("compressed", "").lower() == "true"
+            return self._decode_plantumlcloud_data(data, compressed=compressed)
+
+        def convert_plantumlcloud(
+            self, el: BeautifulSoup, text: str, parent_tags: list[str]
+        ) -> str:
+            """Convert the `plantumlcloud` macro to a Markdown code block.
+
+            The "Flowchart, PlantUML Diagrams for Confluence" app registers this macro
+            name on Confluence Cloud.  Being a Connect app, it renders only an empty
+            iframe placeholder into `body.view` and writes nothing to `editor2`, so the
+            diagram source is recovered from `body.storage`, where it is kept in the
+            macro's `data` parameter.
+            """
+            macro_id = el.get("data-macro-id")
+            uml = self._extract_uml_from_plantumlcloud(str(macro_id) if macro_id else None)
+            if uml:
+                return f"\n```plantuml\n{uml}\n```\n\n"
+
+            logger.warning("PlantUML (plantumlcloud) macro could not be resolved from body.storage")
             return "\n<!-- PlantUML diagram (source not found) -->\n\n"
 
         def convert_include(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:

--- a/docs/features.md
+++ b/docs/features.md
@@ -28,5 +28,5 @@ Exports individual pages, pages with descendants, or entire spaces via the Atlas
 ### Diagrams & add-ons
 
 - **[draw.io](https://marketplace.atlassian.com/apps/1210933/draw-io-diagrams-uml-bpmn-aws-erd-flowcharts)**: diagram files saved as attachments; embedded Mermaid diagrams extracted as fenced Mermaid blocks
-- **[PlantUML](https://marketplace.atlassian.com/apps/1222993/flowchart-plantuml-diagrams-for-confluence)**: exported as fenced PlantUML code blocks
+- **[PlantUML](https://marketplace.atlassian.com/apps/1222993/flowchart-plantuml-diagrams-for-confluence)**: exported as fenced PlantUML code blocks, both the Server/Data Center macro (`plantuml`) and the Cloud macro (`plantumlcloud`); the diagram source is exported, not the rendered image
 - **[Markdown Extensions](https://marketplace.atlassian.com/apps/1215703/markdown-extensions-for-confluence)**: pass-through of raw Markdown macro content

--- a/tests/unit/test_plantumlcloud_conversion.py
+++ b/tests/unit/test_plantumlcloud_conversion.py
@@ -1,0 +1,406 @@
+"""Unit tests for the `plantumlcloud` macro conversion.
+
+The "Flowchart, PlantUML Diagrams for Confluence" app uses the macro name
+`plantumlcloud` on Confluence Cloud and keeps the diagram source in the macro's
+`data` parameter of `body.storage`, base64-encoded and (usually) raw-deflated.
+"""
+
+import base64
+import zlib
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from urllib.parse import quote
+
+import pytest
+from bs4 import BeautifulSoup
+
+from confluence_markdown_exporter.confluence import Page
+
+UML_A = "@startuml\nAlice -> Bob: Hello\n@enduml"
+UML_B = "@startuml\nBob -> Carol: Second\n@enduml"
+
+
+def encode_data(uml: str, *, compressed: bool = True) -> str:
+    """Encode UML source the way the app stores it in the `data` parameter."""
+    payload = quote(uml).encode()
+    if compressed:
+        compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+        payload = compressor.compress(payload) + compressor.flush()
+    return base64.b64encode(payload).decode()
+
+
+def storage_macro(data: str, macro_id: str = "", *, compressed: bool = True) -> str:
+    """Build a `plantumlcloud` structured-macro as it appears in body.storage."""
+    macro_id_attr = f' ac:macro-id="{macro_id}"' if macro_id else ""
+    return (
+        f'<ac:structured-macro ac:name="plantumlcloud"{macro_id_attr} ac:schema-version="1">'
+        '<ac:parameter ac:name="filename">diagram.svg</ac:parameter>'
+        f'<ac:parameter ac:name="data">{data}</ac:parameter>'
+        f'<ac:parameter ac:name="compressed">{str(compressed).lower()}</ac:parameter>'
+        "</ac:structured-macro>"
+    )
+
+
+def view_div(macro_id: str = "") -> str:
+    """Build the empty Connect placeholder the app renders into body.view."""
+    macro_id_attr = f' data-macro-id="{macro_id}"' if macro_id else ""
+    return (
+        '<div class="ap-container conf-macro output-block" data-hasbody="false"'
+        f'{macro_id_attr} data-macro-name="plantumlcloud">'
+        '<div class="ap-content"> </div>'
+        '<script class="ap-iframe-body-script">//<![CDATA[\n'
+        'var data = {"addon_key":"com.mxgraph.confluence.plugins.plantuml"};\n'
+        "//]]></script>"
+        "</div>"
+    )
+
+
+def make_page(body_storage: str) -> MagicMock:
+    page = MagicMock(spec=Page)
+    page.id = 12345
+    page.title = "Test Page"
+    page.html = "<h1>Test Page</h1>"
+    page.labels = []
+    page.ancestors = []
+    page.attachments = []
+    page.editor2 = ""
+    page.body_storage = body_storage
+    return page
+
+
+def element(html: str, tag: str = "div") -> BeautifulSoup:
+    return BeautifulSoup(html, "html.parser").find(tag)
+
+
+class TestPlantUMLCloudConversion:
+    """Test cases for the `plantumlcloud` macro."""
+
+    @pytest.fixture(autouse=True)
+    def _settings(self):  # noqa: ANN202
+        with patch("confluence_markdown_exporter.confluence.settings") as mock_settings:
+            mock_settings.export.include_document_title = False
+            mock_settings.export.page_breadcrumbs = False
+            yield mock_settings
+
+    def test_compressed_macro_matched_by_macro_id(self) -> None:
+        """Compressed source is decoded into a fenced plantuml code block."""
+        page = make_page(storage_macro(encode_data(UML_A), "macro-1"))
+        converter = Page.Converter(page)
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "```plantuml" in result
+        assert "Alice -> Bob: Hello" in result
+        assert result.strip().endswith("```")
+
+    def test_uncompressed_macro(self) -> None:
+        """Base64-only payloads (compressed=false) are decoded as well."""
+        page = make_page(
+            storage_macro(encode_data(UML_A, compressed=False), "macro-1", compressed=False)
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "```plantuml" in result
+        assert "Alice -> Bob: Hello" in result
+
+    def test_macro_id_selects_the_right_diagram(self) -> None:
+        """With several diagrams on the page, each macro-id resolves its own source."""
+        page = make_page(
+            storage_macro(encode_data(UML_A), "macro-1")
+            + "<p>Some text between diagrams</p>"
+            + storage_macro(encode_data(UML_B), "macro-2")
+        )
+        converter = Page.Converter(page)
+
+        # Convert the second diagram first to prove the lookup is not positional.
+        second = converter.convert_plantumlcloud(element(view_div("macro-2")), "", [])
+        first = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "Bob -> Carol: Second" in second
+        assert "Alice -> Bob: Hello" in first
+
+    def test_positional_fallback_without_macro_id(self) -> None:
+        """Without a usable macro-id, diagrams are matched by position."""
+        page = make_page(storage_macro(encode_data(UML_A)) + storage_macro(encode_data(UML_B)))
+        converter = Page.Converter(page)
+
+        first = converter.convert_plantumlcloud(element(view_div()), "", [])
+        second = converter.convert_plantumlcloud(element(view_div()), "", [])
+
+        assert "Alice -> Bob: Hello" in first
+        assert "Bob -> Carol: Second" in second
+
+    def test_positional_cursor_advances_on_macro_id_match(self) -> None:
+        """A macro-id match must not leave the positional cursor behind.
+
+        Otherwise a following macro without a macro-id would re-resolve the
+        already consumed diagram instead of advancing to the next one.
+        """
+        page = make_page(
+            storage_macro(encode_data(UML_A), "macro-1") + storage_macro(encode_data(UML_B))
+        )
+        converter = Page.Converter(page)
+
+        first = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+        second = converter.convert_plantumlcloud(element(view_div()), "", [])
+
+        assert "Alice -> Bob: Hello" in first
+        assert "Bob -> Carol: Second" in second
+
+    def test_cursor_is_not_rewound_by_a_later_macro_id_match(self) -> None:
+        """A macro-id match must not move the positional cursor backwards.
+
+        Resolving an earlier diagram by id in the middle of a positional run would
+        otherwise replay diagrams already emitted and drop the ones still pending.
+        """
+        page = make_page(
+            storage_macro(encode_data("@startuml\nFIRST\n@enduml"), "m1")
+            + storage_macro(encode_data("@startuml\nSECOND\n@enduml"))
+            + storage_macro(encode_data("@startuml\nTHIRD\n@enduml"))
+        )
+        converter = Page.Converter(page)
+
+        results = [
+            converter.convert_plantumlcloud(element(view_div(macro_id)), "", [])
+            for macro_id in ("", "", "m1", "")
+        ]
+
+        assert "FIRST" in results[0]
+        assert "SECOND" in results[1]
+        assert "FIRST" in results[2]
+        assert "THIRD" in results[3]
+
+    def test_more_placeholders_than_stored_macros_emits_comment(self) -> None:
+        """Running past the end of body.storage produces a marker, not a repeat."""
+        page = make_page(storage_macro(encode_data(UML_A)))
+        converter = Page.Converter(page)
+
+        first = converter.convert_plantumlcloud(element(view_div()), "", [])
+        second = converter.convert_plantumlcloud(element(view_div()), "", [])
+
+        assert "Alice -> Bob: Hello" in first
+        assert "<!-- PlantUML diagram" in second
+
+    @pytest.mark.parametrize(
+        "body_storage",
+        [
+            pytest.param(
+                '<ac:structured-macro ac:name="plantumlcloud" ac:macro-id="macro-1">'
+                '<ac:parameter ac:name="filename">diagram.svg</ac:parameter>'
+                "</ac:structured-macro>",
+                id="no-data-parameter",
+            ),
+            pytest.param(storage_macro("", "macro-1"), id="empty-data-parameter"),
+            pytest.param(
+                storage_macro(base64.b64encode(b"   \n  ").decode(), "macro-1", compressed=False),
+                id="whitespace-only-payload",
+            ),
+        ],
+    )
+    def test_malformed_macro_emits_comment(self, body_storage: str) -> None:
+        """A macro that carries no usable source produces a marker, never an exception."""
+        converter = Page.Converter(make_page(body_storage))
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "<!-- PlantUML diagram" in result
+
+    def test_foreign_macro_id_emits_comment(self) -> None:
+        """A macro-id unknown to body.storage must not resolve to another diagram.
+
+        An include macro expands the transcluded page's view HTML into this page, so
+        its placeholders carry macro-ids that only the other page's storage knows.
+        Falling back to position would export an unrelated diagram.
+        """
+        page = make_page(storage_macro(encode_data(UML_A), "macro-1"))
+        converter = Page.Converter(page)
+
+        foreign = converter.convert_plantumlcloud(element(view_div("foreign-9")), "", [])
+        own = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "<!-- PlantUML diagram" in foreign
+        assert "Alice -> Bob: Hello" not in foreign
+        assert "Alice -> Bob: Hello" in own
+
+    def test_unknown_macro_id_falls_back_when_storage_has_no_ids(self) -> None:
+        """Positional matching still applies when storage carries no macro-ids at all."""
+        page = make_page(storage_macro(encode_data(UML_A)))
+        converter = Page.Converter(page)
+
+        result = converter.convert_plantumlcloud(element(view_div("some-id")), "", [])
+
+        assert "Alice -> Bob: Hello" in result
+
+    def test_unknown_macro_id_falls_back_when_storage_ids_are_partial(self) -> None:
+        """A page mixing identified and unidentified macros must not lose a diagram.
+
+        The foreign-macro guard may only suppress the fallback when every stored macro
+        is identifiable, otherwise an unidentified diagram becomes unreachable.
+        """
+        page = make_page(
+            storage_macro(encode_data(UML_A)) + storage_macro(encode_data(UML_B), "m2")
+        )
+        converter = Page.Converter(page)
+
+        first = converter.convert_plantumlcloud(element(view_div("generated-1")), "", [])
+        second = converter.convert_plantumlcloud(element(view_div("m2")), "", [])
+
+        assert "Alice -> Bob: Hello" in first
+        assert "Bob -> Carol: Second" in second
+
+    def test_absent_compressed_parameter_means_uncompressed(self) -> None:
+        """A macro without a `compressed` parameter is read as plain base64."""
+        payload = base64.b64encode(UML_A.encode()).decode()
+        page = make_page(
+            '<ac:structured-macro ac:name="plantumlcloud" ac:macro-id="macro-1">'
+            f'<ac:parameter ac:name="data">{payload}</ac:parameter>'
+            "</ac:structured-macro>"
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "Alice -> Bob: Hello" in result
+
+    def test_nested_parameters_are_ignored(self) -> None:
+        """Only the macro's own parameters count, not those of a macro nested in its body."""
+        page = make_page(
+            '<ac:structured-macro ac:name="plantumlcloud" ac:macro-id="macro-1">'
+            f'<ac:parameter ac:name="data">{encode_data(UML_A)}</ac:parameter>'
+            '<ac:parameter ac:name="compressed">true</ac:parameter>'
+            "<ac:rich-text-body>"
+            '<ac:structured-macro ac:name="expand">'
+            '<ac:parameter ac:name="data">bogus-nested-payload</ac:parameter>'
+            '<ac:parameter ac:name="compressed">false</ac:parameter>'
+            "</ac:structured-macro>"
+            "</ac:rich-text-body>"
+            "</ac:structured-macro>"
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "Alice -> Bob: Hello" in result
+        assert "bogus" not in result
+
+    def test_line_wrapped_base64_is_decoded(self) -> None:
+        """Whitespace inside the base64 value must not break decoding.
+
+        Emitting the undecoded parameter as if it were diagram source would put a
+        base64 blob into the export.
+        """
+        data = encode_data(UML_A)
+        wrapped = f"{data[:20]}\n{data[20:]}"
+        page = make_page(storage_macro(wrapped, "macro-1"))
+        converter = Page.Converter(page)
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "Alice -> Bob: Hello" in result
+        assert data[:20] not in result
+
+    def test_literal_percent_is_preserved(self) -> None:
+        """A literal `%` in the source survives: `%date%` is a PlantUML built-in."""
+        uml = "@startuml\ntitle %date% 100%\nAlice -> Bob: Hello\n@enduml"
+        payload = base64.b64encode(uml.encode()).decode()
+        page = make_page(storage_macro(payload, "macro-1", compressed=False))
+        converter = Page.Converter(page)
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "title %date% 100%" in result
+
+    def test_percent_encoded_uncompressed_payload_is_decoded(self) -> None:
+        """An uncompressed but percent-encoded payload is still decoded."""
+        payload = base64.b64encode(quote(UML_A).encode()).decode()
+        page = make_page(storage_macro(payload, "macro-1", compressed=False))
+        converter = Page.Converter(page)
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "Alice -> Bob: Hello" in result
+        assert "%40startuml" not in result
+
+    def test_corrupt_data_emits_comment(self) -> None:
+        """Undecodable payloads produce a comment instead of raising."""
+        page = make_page(storage_macro(base64.b64encode(b"not deflated").decode(), "macro-1"))
+        converter = Page.Converter(page)
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "<!-- PlantUML diagram" in result
+        assert "source not found" in result
+
+    def test_truncated_payload_emits_comment(self) -> None:
+        """A truncated deflate stream inflates without error; it must not be exported.
+
+        Half a diagram rendered as if it were whole is worse than a visible marker.
+        """
+        compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+        full = compressor.compress(quote(UML_A).encode()) + compressor.flush()
+        truncated = base64.b64encode(full[: len(full) // 2]).decode()
+        page = make_page(storage_macro(truncated, "macro-1"))
+        converter = Page.Converter(page)
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "<!-- PlantUML diagram" in result
+        assert "@startuml" not in result
+
+    def test_oversized_payload_emits_comment(self) -> None:
+        """A highly compressible payload is not inflated without bound."""
+        compressor = zlib.compressobj(wbits=-zlib.MAX_WBITS)
+        bomb = compressor.compress(b"A" * (8 * 1024 * 1024)) + compressor.flush()
+        page = make_page(storage_macro(base64.b64encode(bomb).decode(), "macro-1"))
+        converter = Page.Converter(page)
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "<!-- PlantUML diagram" in result
+        assert "source not found" in result
+
+    def test_missing_storage_emits_comment(self) -> None:
+        """An empty body.storage produces a comment instead of silent omission."""
+        converter = Page.Converter(make_page(""))
+
+        result = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+
+        assert "<!-- PlantUML diagram" in result
+
+    def test_convert_div_dispatches_plantumlcloud(self) -> None:
+        """End-to-end: the placeholder div converts to a code block, script is dropped."""
+        page = make_page(storage_macro(encode_data(UML_A), "macro-1"))
+        converter = Page.Converter(page)
+
+        result = converter.convert(view_div("macro-1"))
+
+        assert "```plantuml" in result
+        assert "Alice -> Bob: Hello" in result
+        assert "addon_key" not in result
+        assert "var data" not in result
+
+    def test_both_macro_flavours_on_one_page(self) -> None:
+        """Server `plantuml` and Cloud `plantumlcloud` macros stay independent.
+
+        Both flavours share the body.storage macro cache, so a page holding one of
+        each must resolve both without cross-talk.
+        """
+        server_uml = "@startuml\nCarol -> Dave: Server\n@enduml"
+        page = make_page(
+            '<ac:structured-macro ac:name="plantuml">'
+            f"<ac:plain-text-body><![CDATA[{server_uml}]]></ac:plain-text-body>"
+            "</ac:structured-macro>" + storage_macro(encode_data(UML_A), "macro-1")
+        )
+        converter = Page.Converter(page)
+
+        cloud = converter.convert_plantumlcloud(element(view_div("macro-1")), "", [])
+        server = converter.convert_plantuml(
+            element('<span data-macro-name="plantuml"></span>', "span"), "", []
+        )
+
+        assert "Alice -> Bob: Hello" in cloud
+        assert "Carol -> Dave: Server" not in cloud
+        assert "Carol -> Dave: Server" in server
+        assert "Alice -> Bob: Hello" not in server


### PR DESCRIPTION
Fixes #290

## Summary

Pages using the [Flowchart, PlantUML Diagrams for Confluence](https://marketplace.atlassian.com/apps/1222993/flowchart-plantuml-diagrams-for-confluence) app currently export with the diagram missing entirely: no code block, no image, not even a marker.

On Confluence Cloud that app registers the macro name **`plantumlcloud`**, while only `plantuml` was dispatched in `macro_handlers`. Being a Connect app, it renders nothing but an empty iframe placeholder into `body.view` and writes nothing to `editor2`, so the unhandled macro fell through to markdownify's default `convert_div` and produced an empty string.

`docs/features.md` already linked to this exact marketplace app and promised fenced PlantUML blocks, so this closes a gap between the documented and actual behaviour.

### What it does

The diagram source lives in `body.storage`, in the macro's `data` parameter: base64, and when the sibling `compressed` parameter is `true`, additionally raw-DEFLATE-compressed and percent-encoded (the mxgraph/draw.io encoding). The new `convert_plantumlcloud` handler recovers it and emits a fenced `plantuml` block, matching what the existing Server/DC `plantuml` handler produces.

The rendered `.svg`/`.png` attachments are deliberately **not** embedded; the diagram source is exported, as documented.

### Decoding is deliberately defensive

`body.storage` is remote content, so every failure mode degrades to a visible `<!-- PlantUML diagram (source not found) -->` marker plus a log warning, never to wrong or empty output:

- the inflate is bounded at 4 MB and rejects truncated streams, which inflate without raising and would otherwise be exported as a silently partial diagram;
- base64 decoding tolerates line wrapping, but never falls back to emitting the undecoded parameter;
- percent-decoding is applied only when the text is actually encoded, because PlantUML sources legitimately contain a literal `%` (`%date%`, `%filename()`).

### Macro matching

Macros are matched by `macro-id`, falling back to document order only when `body.storage` carries no `macro-id` at all. A placeholder whose `macro-id` is unknown to this page belongs to a transcluded page (an `include` macro expands another page's view HTML inline), so it resolves to the marker rather than to an unrelated diagram.

### Refactors carried along

- `_storage_plantuml_macros` generalised into `_storage_macros_by_name(name)` with a name-keyed cache; the existing `plantuml` path is unchanged.
- The parameter-extraction loop duplicated between the panel-icon code and the new code extracted into `_macro_params()`.

## Test Plan

- `tests/unit/test_plantumlcloud_conversion.py` adds 24 tests using synthetic diagram sources: happy path, compressed and uncompressed payloads, line-wrapped base64, literal `%` preservation, `macro-id` selection, positional fallback and cursor semantics, foreign/transcluded `macro-id`, truncated and oversized payloads, nested parameters, and a case with both macro flavours on one page guarding the shared cache.
- `uv run pytest`: **466 passed** (442 before this change).
- `uv run ruff check` and `uv run ruff format --check`: clean.
- `uv build --no-sources`: builds.
- Verified end to end against a real Cloud page holding 5 `plantumlcloud` diagrams: all 5 export as `plantuml` fences with no "source not found" markers.
