### PR TITLE
feat: convert Graphviz graphviz/digraph macros to fenced DOT blocks

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -87,6 +87,30 @@ _RE_RGB_COLOR = re.compile(r"(?<![a-z-])color:\s*rgb\((\d+),\s*(\d+),\s*(\d+)\)"
 _RE_COLORID_CSS = re.compile(r"(?<![>\w])\[data-colorid=(\w+)\]\{color:(#[0-9a-fA-F]+)\}")
 _RE_HEX_COLOR = re.compile(r"^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
 
+# Graphviz macros of the "Graphviz Diagrams for Confluence" app, mapped to the DOT graph
+# keyword their body has to be wrapped in. The `graphviz` macro body is already a complete
+# DOT document (empty keyword); the `digraph` macro body holds only the statements and gets
+# its graph header from the plugin at render time.
+_GRAPHVIZ_MACROS: dict[str, str] = {"graphviz": "", "digraph": "digraph"}
+
+# Matches a DOT graph header such as `digraph name {`: the keyword, an optional graph ID,
+# then the opening brace. Deliberately strict on both sides of the ID — a permissive gap
+# before the brace would also match ordinary code such as Python's `graph = {...}`, and the
+# brace has to sit on the header line so Mermaid's `graph TD` / `graph LR` is not read as DOT.
+_RE_DOT_GRAPH_HEADER = re.compile(
+    r'^\s*(?:strict\s+)?(?:di)?graph\s*(?:[A-Za-z_]\w*|\d+|"[^"\n]*")?\s*\{',
+    re.IGNORECASE,
+)
+
+# Leading DOT comments, stripped before header detection so a pasted document that opens
+# with a comment is still recognised as already having its graph header.
+_RE_DOT_LEADING_COMMENTS = re.compile(r"^(?:\s*(?://|#)[^\n]*\n|\s*/\*.*?\*/)+", re.DOTALL)
+
+_RE_DOT_BARE_ID = re.compile(r"^[A-Za-z_][A-Za-z_0-9]*$")
+
+# DOT reserved words. Valid as a graph name only when quoted.
+_DOT_KEYWORDS = frozenset({"digraph", "edge", "graph", "node", "strict", "subgraph"})
+
 # Confluence default header backgrounds — applied automatically to <th> cells, and
 # (in matrix-style tables) to row-label <td>s. Treated as "no user-chosen colour".
 _DEFAULT_HEADER_BGS = frozenset({"#f4f5f7", "#f2f2f2"})
@@ -94,6 +118,51 @@ _DEFAULT_HEADER_BGS = frozenset({"#f4f5f7", "#f2f2f2"})
 
 def _rgb_to_hex(r: int, g: int, b: int) -> str:
     return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def _dot_id(name: str) -> str:
+    """Return `name` as a DOT identifier, quoting it when it is not a bare ID.
+
+    Reserved words are quoted too: `digraph graph { ... }` is a DOT syntax error.
+    """
+    if _RE_DOT_BARE_ID.match(name) and name.lower() not in _DOT_KEYWORDS:
+        return name
+    escaped = name.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _has_dot_graph_header(source: str) -> bool:
+    """Return whether `source` opens with a DOT graph header, ignoring leading comments."""
+    return bool(_RE_DOT_GRAPH_HEADER.match(_RE_DOT_LEADING_COMMENTS.sub("", source, count=1)))
+
+
+def _dot_attribute_statements(attributes: str) -> str:
+    """Normalise a Graphviz macro `attributes` value into DOT statements.
+
+    The parameter is usually written as a Graphviz attribute list
+    (`rankdir=LR, size="8,5"`), but a comma is not a valid statement separator at graph
+    level, so top-level commas are rewritten to semicolons. Commas inside quoted values
+    are left alone. A value that already uses semicolons is taken to be statements
+    already and passes through untouched.
+    """
+    if ";" in attributes:
+        return attributes
+
+    out: list[str] = []
+    in_quotes = False
+    is_escaped = False
+    for char in attributes:
+        if is_escaped:
+            is_escaped = False
+        elif char == "\\":
+            is_escaped = True
+        elif char == '"':
+            in_quotes = not in_quotes
+        elif char == "," and not in_quotes:
+            out.append(";")
+            continue
+        out.append(char)
+    return "".join(out)
 
 
 def _render_meta_bind_view_fields(props: dict[str, str], mode: str) -> str:
@@ -1477,8 +1546,9 @@ class Page(Document):
             self._colorid_map_cache: dict[str, str] | None = None
             self._image_captions_cache: dict[str, str] | None = None
             self._panel_icon_map_cache: dict[str, str] | None = None
-            self._plantuml_index: int = 0
-            self._storage_plantuml_macros_cache: list[Tag] | None = None
+            self._storage_macros_cache: dict[str, list[Tag]] = {}
+            self._storage_macro_positions: dict[str, int] = {}
+            self._editor2_soup_cache: BeautifulSoup | None = None
 
         @property
         def _colorid_map(self) -> dict[str, str]:
@@ -1494,21 +1564,64 @@ class Page(Document):
                 self._colorid_map_cache = cache
             return self._colorid_map_cache
 
-        @property
-        def _storage_plantuml_macros(self) -> list[Tag]:
-            """Cache and return all PlantUML structured-macros from body.storage."""
-            if self._storage_plantuml_macros_cache is None:
-                macros: list[Tag] = []
+        def _storage_macros(self, name: str) -> list[Tag]:
+            """Cache and return all structured-macros named `name` from body.storage."""
+            macros = self._storage_macros_cache.get(name)
+            if macros is None:
+                macros = []
                 if self.page.body_storage:
                     wrapped = f"<root>{self.page.body_storage}</root>"
                     soup = BeautifulSoup(wrapped, "xml")
                     macros.extend(
                         macro
                         for macro in soup.find_all("structured-macro")
-                        if isinstance(macro, Tag) and macro.get("name") == "plantuml"
+                        if isinstance(macro, Tag) and macro.get("name") == name
                     )
-                self._storage_plantuml_macros_cache = macros
-            return self._storage_plantuml_macros_cache
+                self._storage_macros_cache[name] = macros
+            return macros
+
+        def _next_storage_macro(self, name: str) -> Tag | None:
+            """Return the next unconsumed body.storage macro named `name`.
+
+            Server / Data Center view HTML carries no `data-macro-id`, so macros are
+            matched by position: the Nth occurrence in the view HTML is the Nth macro
+            of that name in body.storage. Positions are tracked per macro name so
+            different macro types do not consume each other's slots.
+            """
+            macros = self._storage_macros(name)
+            idx = self._storage_macro_positions.get(name, 0)
+            self._storage_macro_positions[name] = idx + 1
+            return macros[idx] if idx < len(macros) else None
+
+        @property
+        def _editor2_soup(self) -> BeautifulSoup | None:
+            """Parse and cache the page's editor2 XML, or None when the page has none."""
+            if self._editor2_soup_cache is None:
+                if not self.page.editor2:
+                    return None
+                wrapped = f"<root>{self.page.editor2}</root>"
+                self._editor2_soup_cache = BeautifulSoup(wrapped, "xml")
+            return self._editor2_soup_cache
+
+        def _editor2_macro(self, name: str, macro_id: str) -> Tag | None:
+            """Find a structured-macro in editor2 XML by name and macro-id (Cloud format)."""
+            soup = self._editor2_soup
+            if soup is None:
+                return None
+            for macro in soup.find_all("structured-macro"):
+                if not isinstance(macro, Tag):
+                    continue
+                if macro.get("name") == name and macro.get("macro-id") == macro_id:
+                    return macro
+            return None
+
+        @staticmethod
+        def _macro_parameter(macro: Tag, name: str) -> str | None:
+            """Return the value of a structured-macro `<ac:parameter>`, or None."""
+            for param in macro.find_all("parameter", recursive=False):
+                if isinstance(param, Tag) and param.get("name") == name:
+                    return param.get_text(strip=True) or None
+            return None
 
         @property
         def _image_captions(self) -> dict[str, str]:
@@ -1741,6 +1854,8 @@ class Page(Document):
                     "details": self.convert_page_properties,
                     "drawio": self.convert_drawio,
                     "plantuml": self.convert_plantuml,
+                    "graphviz": self.convert_graphviz,
+                    "digraph": self.convert_graphviz,
                     "scroll-ignore": self.convert_hidden_content,
                     "toc": self.convert_toc,
                     "jira": self.convert_jira_table,
@@ -1846,6 +1961,8 @@ class Page(Document):
                         return result
                 if el["data-macro-name"] == "plantuml":
                     return self.convert_plantuml(el, text, parent_tags)
+                if el["data-macro-name"] in _GRAPHVIZ_MACROS:
+                    return self.convert_graphviz(el, text, parent_tags)
 
             if el.has_attr("class") and "inline-comment-marker" in el["class"]:
                 return self.convert_inline_comment_marker(el, text, parent_tags)
@@ -2002,6 +2119,10 @@ class Page(Document):
 
             if "@startuml" in text:
                 code_language = "plantuml"
+            elif not code_language and _has_dot_graph_header(text):
+                # Only when no brush language was declared: a bare `graph`/`digraph`
+                # keyword is far weaker evidence than `@startuml`.
+                code_language = "dot"
 
             return f"\n\n```{code_language}\n{text}\n```\n\n"
 
@@ -2439,35 +2560,26 @@ class Page(Document):
 
         def _extract_uml_from_editor2(self, macro_id: str) -> str | None:
             """Extract PlantUML source from editor2 XML by macro-id (Cloud format)."""
-            if not self.page.editor2:
+            macro = self._editor2_macro("plantuml", macro_id)
+            if macro is None:
                 return None
-            wrapped = f"<root>{self.page.editor2}</root>"
-            soup = BeautifulSoup(wrapped, "xml")
-            for macro in soup.find_all("structured-macro"):
-                if not isinstance(macro, Tag):
-                    continue
-                if macro.get("name") != "plantuml" or macro.get("macro-id") != macro_id:
-                    continue
-                plain_text_body = macro.find("plain-text-body")
-                if not isinstance(plain_text_body, Tag):
-                    continue
-                cdata = plain_text_body.get_text(strip=True)
-                if not cdata:
-                    continue
-                try:
-                    return json.loads(cdata).get("umlDefinition") or None
-                except json.JSONDecodeError:
-                    return None
-            return None
+            plain_text_body = macro.find("plain-text-body")
+            if not isinstance(plain_text_body, Tag):
+                return None
+            cdata = plain_text_body.get_text(strip=True)
+            if not cdata:
+                return None
+            try:
+                return json.loads(cdata).get("umlDefinition") or None
+            except json.JSONDecodeError:
+                return None
 
         def _extract_uml_from_storage(self) -> str | None:
             """Extract PlantUML source from body.storage by position (Server format)."""
-            storage_macros = self._storage_plantuml_macros
-            idx = self._plantuml_index
-            self._plantuml_index += 1
-            if idx >= len(storage_macros):
+            macro = self._next_storage_macro("plantuml")
+            if macro is None:
                 return None
-            plain_text_body = storage_macros[idx].find("plain-text-body")
+            plain_text_body = macro.find("plain-text-body")
             if not isinstance(plain_text_body, Tag):
                 return None
             uml = plain_text_body.get_text(strip=True)
@@ -2504,6 +2616,70 @@ class Page(Document):
 
             logger.warning("PlantUML macro could not be resolved from editor2 or body.storage")
             return "\n<!-- PlantUML diagram (source not found) -->\n\n"
+
+        def _wrap_dot_source(self, macro_name: str, macro: Tag, body: str) -> str:
+            """Reconstruct a complete DOT document from a Graphviz macro body.
+
+            The `graphviz` macro body is already a complete DOT document. The `digraph`
+            macro body holds only the statements — the plugin supplies the graph header
+            when rendering — so the header is rebuilt here from the macro's `name` and
+            `attributes` parameters to yield DOT that renders standalone.
+            """
+            keyword = _GRAPHVIZ_MACROS.get(macro_name, "")
+            if not keyword or _has_dot_graph_header(body):
+                return body
+
+            graph_name = _dot_id(self._macro_parameter(macro, "name") or "G")
+            attributes = self._macro_parameter(macro, "attributes")
+            statements = f"{_dot_attribute_statements(attributes)}\n{body}" if attributes else body
+            # Statements are emitted verbatim: DOT permits line-continued quoted strings
+            # and HTML-like labels whose content would change if re-indented.
+            return f"{keyword} {graph_name} {{\n{statements}\n}}"
+
+        def _extract_dot_from_macro(self, macro_name: str, macro: Tag) -> str | None:
+            """Return the complete DOT source held by a Graphviz structured-macro."""
+            plain_text_body = macro.find("plain-text-body")
+            if not isinstance(plain_text_body, Tag):
+                return None
+            body = plain_text_body.get_text().strip()
+            if not body:
+                return None
+            return self._wrap_dot_source(macro_name, macro, body)
+
+        def convert_graphviz(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
+            """Convert Graphviz `graphviz` / `digraph` macros to fenced DOT code blocks.
+
+            Source lookup mirrors `convert_plantuml`: editor2 XML by ``macro-id`` first
+            (Cloud), then positional matching against ``body.storage`` (Server / Data
+            Center, where the view HTML carries no ``macro-id``). Unlike PlantUML, the
+            body is raw DOT rather than a JSON envelope.
+            """
+            macro_name = str(el.get("data-macro-name", ""))
+            dot: str | None = None
+
+            # Consumed up front, and unconditionally, so that positions stay aligned with
+            # the view HTML even when some diagrams on the page resolve through editor2:
+            # advancing only on fallback would pair later diagrams with earlier sources.
+            storage_macro = self._next_storage_macro(macro_name)
+
+            # Strategy 1: editor2 with macro-id (Cloud)
+            macro_id = el.get("data-macro-id")
+            if macro_id:
+                macro = self._editor2_macro(macro_name, str(macro_id))
+                if macro is not None:
+                    dot = self._extract_dot_from_macro(macro_name, macro)
+
+            # Strategy 2: body.storage fallback (Server / Data Center)
+            if not dot and storage_macro is not None:
+                dot = self._extract_dot_from_macro(macro_name, storage_macro)
+
+            if dot:
+                return f"\n```dot\n{dot}\n```\n\n"
+
+            logger.warning(
+                f"Graphviz '{macro_name}' macro could not be resolved from editor2 or body.storage"
+            )
+            return "\n<!-- Graphviz diagram (source not found) -->\n\n"
 
         def convert_include(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
             """Convert Confluence `include` / `excerpt-include` macro.

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,7 +11,7 @@ Exports individual pages, pages with descendants, or entire spaces via the Atlas
 ### Content & formatting
 
 - **Rich text**: headings, paragraphs, bold, italic, underline, lists, tables, links, images, attachments, and image captions
-- **Code blocks**: language-aware fenced code blocks
+- **Code blocks**: language-aware fenced code blocks; blocks holding PlantUML or Graphviz DOT source are detected and fenced as `plantuml` / `dot` even when the Code macro declares no language
 - **Task lists**: checkboxes with completion state
 - **Text highlights & font colours**: preserved with inline HTML colour styling
 - **Status badges**: converted to coloured inline highlights
@@ -29,4 +29,5 @@ Exports individual pages, pages with descendants, or entire spaces via the Atlas
 
 - **[draw.io](https://marketplace.atlassian.com/apps/1210933/draw-io-diagrams-uml-bpmn-aws-erd-flowcharts)**: diagram files saved as attachments; embedded Mermaid diagrams extracted as fenced Mermaid blocks
 - **[PlantUML](https://marketplace.atlassian.com/apps/1222993/flowchart-plantuml-diagrams-for-confluence)**: exported as fenced PlantUML code blocks
+- **[Graphviz](https://marketplace.atlassian.com/apps/257/graphviz-diagrams-for-confluence)**: `graphviz` and `digraph` macros exported as fenced `dot` code blocks; the `digraph` macro's graph header is reconstructed from its `name` and `attributes` parameters so the DOT renders standalone
 - **[Markdown Extensions](https://marketplace.atlassian.com/apps/1215703/markdown-extensions-for-confluence)**: pass-through of raw Markdown macro content

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ hide:
 
 -   :material-puzzle: __Macros and add-ons__
 
-    Status badges, panels, page properties, draw.io, PlantUML, Mermaid, include/excerpt: all converted to portable Markdown.
+    Status badges, panels, page properties, draw.io, PlantUML, Graphviz, Mermaid, include/excerpt: all converted to portable Markdown.
 
     [:octicons-arrow-right-24: Features](features.md)
 

--- a/tests/unit/test_graphviz_conversion.py
+++ b/tests/unit/test_graphviz_conversion.py
@@ -1,0 +1,594 @@
+"""Unit tests for Graphviz (`graphviz` / `digraph` macro) diagram conversion."""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from bs4 import BeautifulSoup
+from bs4 import Tag
+
+from confluence_markdown_exporter.confluence import Page
+
+
+def _make_page(**overrides: object) -> MagicMock:
+    page = MagicMock(spec=Page)
+    page.id = 12345
+    page.title = "Test Page"
+    page.html = "<h1>Test Page</h1>"
+    page.labels = []
+    page.ancestors = []
+    page.attachments = []
+    page.editor2 = ""
+    page.body_storage = ""
+    for key, value in overrides.items():
+        setattr(page, key, value)
+    return page
+
+
+def _storage_macro(name: str, body: str, params: str = "") -> str:
+    return (
+        f'<ac:structured-macro ac:name="{name}">'
+        f"{params}"
+        f"<ac:plain-text-body><![CDATA[{body}]]></ac:plain-text-body>"
+        "</ac:structured-macro>"
+    )
+
+
+def _el(html: str, tag: str) -> Tag:
+    """Return the first `tag` in `html`, failing the test if the fixture has no such tag."""
+    element = BeautifulSoup(html, "html.parser").find(tag)
+    assert isinstance(element, Tag), f"fixture HTML has no <{tag}>: {html}"
+    return element
+
+
+class TestGraphvizMacroConversion:
+    """Conversion of the `graphviz` macro, whose body is already complete DOT."""
+
+    @pytest.fixture(autouse=True)
+    def _settings(self):  # noqa: ANN202
+        with patch("confluence_markdown_exporter.confluence.settings") as mock_settings:
+            mock_settings.export.include_document_title = False
+            mock_settings.export.page_breadcrumbs = False
+            mock_settings.export.convert_text_highlights = False
+            mock_settings.export.convert_font_colors = False
+            yield mock_settings
+
+    def test_graphviz_from_storage_is_emitted_verbatim(self) -> None:
+        """A `graphviz` body is complete DOT and must not be re-wrapped."""
+        page = _make_page(
+            body_storage=_storage_macro("graphviz", "digraph G {\n  a -> b;\n}"),
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="graphviz"></div>', "div"), "", []
+        )
+
+        assert result == "\n```dot\ndigraph G {\n  a -> b;\n}\n```\n\n"
+
+    def test_graphviz_from_editor2_by_macro_id(self) -> None:
+        """Cloud pages resolve the macro through editor2 XML by macro-id."""
+        page = _make_page(
+            editor2=(
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                '<ac:structured-macro ac:name="graphviz" ac:macro-id="gv-1">'
+                "<ac:plain-text-body><![CDATA[digraph G { x -> y }]]></ac:plain-text-body>"
+                "</ac:structured-macro>"
+            ),
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="graphviz" data-macro-id="gv-1"></div>', "div"), "", []
+        )
+
+        assert "```dot" in result
+        assert "digraph G { x -> y }" in result
+
+    def test_graphviz_editor2_miss_falls_back_to_storage(self) -> None:
+        """An unmatched macro-id falls through to the body.storage lookup."""
+        page = _make_page(
+            editor2=(
+                '<ac:structured-macro ac:name="graphviz" ac:macro-id="other-id">'
+                "<ac:plain-text-body><![CDATA[digraph G { wrong }]]></ac:plain-text-body>"
+                "</ac:structured-macro>"
+            ),
+            body_storage=_storage_macro("graphviz", "digraph G { correct }"),
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="graphviz" data-macro-id="missing"></div>', "div"), "", []
+        )
+
+        assert "correct" in result
+        assert "wrong" not in result
+
+    def test_undirected_graph_body_kept_as_is(self) -> None:
+        """An undirected graph written into the `graphviz` macro survives untouched."""
+        page = _make_page(body_storage=_storage_macro("graphviz", "graph G {\n  a -- b;\n}"))
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="graphviz"></div>', "div"), "", []
+        )
+
+        assert "graph G {\n  a -- b;\n}" in result
+        assert "digraph" not in result
+
+
+class TestDigraphMacroConversion:
+    """Conversion of the `digraph` macro, whose body holds only DOT statements."""
+
+    @pytest.fixture(autouse=True)
+    def _settings(self):  # noqa: ANN202
+        with patch("confluence_markdown_exporter.confluence.settings") as mock_settings:
+            mock_settings.export.include_document_title = False
+            mock_settings.export.convert_text_highlights = False
+            mock_settings.export.convert_font_colors = False
+            yield mock_settings
+
+    def test_digraph_body_is_wrapped_in_graph_header(self) -> None:
+        """The plugin-supplied `digraph G { ... }` header has to be reconstructed."""
+        page = _make_page(body_storage=_storage_macro("digraph", "A -> B -> C"))
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert result == "\n```dot\ndigraph G {\nA -> B -> C\n}\n```\n\n"
+
+    def test_digraph_name_parameter_is_used(self) -> None:
+        """The `name` parameter becomes the DOT graph name."""
+        page = _make_page(
+            body_storage=_storage_macro(
+                "digraph",
+                "A -> B",
+                params='<ac:parameter ac:name="name">MyGraph</ac:parameter>',
+            ),
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert "digraph MyGraph {" in result
+
+    def test_digraph_name_with_spaces_is_quoted(self) -> None:
+        """A graph name that is not a bare DOT ID must be quoted."""
+        page = _make_page(
+            body_storage=_storage_macro(
+                "digraph",
+                "A -> B",
+                params='<ac:parameter ac:name="name">My Graph</ac:parameter>',
+            ),
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert 'digraph "My Graph" {' in result
+
+    def test_digraph_attributes_parameter_is_prepended(self) -> None:
+        """Graph attributes held in the `attributes` parameter are not dropped."""
+        page = _make_page(
+            body_storage=_storage_macro(
+                "digraph",
+                "A -> B",
+                params='<ac:parameter ac:name="attributes">rankdir=LR;</ac:parameter>',
+            ),
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert result == "\n```dot\ndigraph G {\nrankdir=LR;\nA -> B\n}\n```\n\n"
+
+    def test_digraph_body_that_already_has_header_is_not_double_wrapped(self) -> None:
+        """Authors sometimes paste a full document into the `digraph` macro."""
+        page = _make_page(body_storage=_storage_macro("digraph", "digraph G {\n  A -> B;\n}"))
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert result.count("digraph G {") == 1
+
+    @pytest.mark.parametrize(
+        "comment",
+        ["// my graph", "# my graph", "/* my graph */", "// first\n// second"],
+    )
+    def test_leading_comment_does_not_defeat_the_header_check(self, comment: str) -> None:
+        """A pasted document opening with a comment must not be wrapped again.
+
+        Nesting `digraph` inside `digraph` is a DOT syntax error — only `subgraph` nests.
+        """
+        page = _make_page(
+            body_storage=_storage_macro("digraph", f"{comment}\ndigraph G {{\n  A -> B;\n}}"),
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert result.count("digraph G {") == 1
+
+    @pytest.mark.parametrize("name", ["graph", "digraph", "node", "edge", "subgraph", "strict"])
+    def test_reserved_word_graph_name_is_quoted(self, name: str) -> None:
+        """`digraph graph { ... }` is a DOT syntax error, so keywords must be quoted."""
+        page = _make_page(
+            body_storage=_storage_macro(
+                "digraph",
+                "A -> B",
+                params=f'<ac:parameter ac:name="name">{name}</ac:parameter>',
+            ),
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert f'digraph "{name}" {{' in result
+
+    def test_comma_separated_attributes_become_statements(self) -> None:
+        """A comma is not a valid statement separator at graph level."""
+        page = _make_page(
+            body_storage=_storage_macro(
+                "digraph",
+                "A -> B",
+                params=('<ac:parameter ac:name="attributes">rankdir=LR, size="8,5"</ac:parameter>'),
+            ),
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        # The comma inside the quoted `size` value has to survive.
+        assert 'rankdir=LR; size="8,5"' in result
+
+    def test_semicolon_attributes_pass_through_unchanged(self) -> None:
+        """A value that already reads as statements is left alone."""
+        page = _make_page(
+            body_storage=_storage_macro(
+                "digraph",
+                "A -> B",
+                params=(
+                    '<ac:parameter ac:name="attributes">rankdir=LR;\nbgcolor=white;</ac:parameter>'
+                ),
+            ),
+        )
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert "rankdir=LR;\nbgcolor=white;\nA -> B" in result
+
+    def test_multiline_body_is_not_reindented(self) -> None:
+        """Bodies are emitted verbatim so line-continued strings stay intact."""
+        body = 'A [label="first\\\nsecond"]\nA -> B'
+        page = _make_page(body_storage=_storage_macro("digraph", body))
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert body in result
+
+
+class TestGraphvizPositionalMatching:
+    """Server / Data Center pages match macros by position, per macro name."""
+
+    @pytest.fixture(autouse=True)
+    def _settings(self):  # noqa: ANN202
+        with patch("confluence_markdown_exporter.confluence.settings") as mock_settings:
+            mock_settings.export.include_document_title = False
+            mock_settings.export.convert_text_highlights = False
+            mock_settings.export.convert_font_colors = False
+            yield mock_settings
+
+    def test_multiple_digraphs_match_in_order(self) -> None:
+        page = _make_page(
+            body_storage=(
+                _storage_macro("digraph", "A -> B")
+                + "<p>text between</p>"
+                + _storage_macro("digraph", "C -> D")
+            ),
+        )
+        converter = Page.Converter(page)
+
+        first = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+        second = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert "A -> B" in first
+        assert "C -> D" in second
+
+    def test_macro_names_have_independent_positions(self) -> None:
+        """A `graphviz` macro must not consume the `digraph` macro's slot."""
+        page = _make_page(
+            body_storage=(
+                _storage_macro("digraph", "A -> B")
+                + _storage_macro("graphviz", "digraph Full { C -> D }")
+            ),
+        )
+        converter = Page.Converter(page)
+
+        graphviz_result = converter.convert_graphviz(
+            _el('<div data-macro-name="graphviz"></div>', "div"), "", []
+        )
+        digraph_result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert "digraph Full { C -> D }" in graphviz_result
+        assert "digraph G {\nA -> B\n}" in digraph_result
+
+    def test_editor2_hit_still_advances_the_storage_position(self) -> None:
+        """A diagram resolved through editor2 must not leave its storage slot unconsumed.
+
+        Otherwise the next diagram falls back to slot 0 and silently renders the first
+        diagram's source.
+        """
+        page = _make_page(
+            editor2=(
+                '<ac:structured-macro ac:name="digraph" ac:macro-id="first">'
+                "<ac:plain-text-body><![CDATA[FROM -> EDITOR2]]></ac:plain-text-body>"
+                "</ac:structured-macro>"
+            ),
+            body_storage=(
+                _storage_macro("digraph", "FIRST -> ONE")
+                + _storage_macro("digraph", "SECOND -> TWO")
+            ),
+        )
+        converter = Page.Converter(page)
+
+        first = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph" data-macro-id="first"></div>', "div"), "", []
+        )
+        # No macro-id, so this one has to come from storage — and from slot 1, not slot 0.
+        second = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert "FROM -> EDITOR2" in first
+        assert "SECOND -> TWO" in second
+        assert "FIRST -> ONE" not in second
+
+    def test_graphviz_does_not_consume_plantuml_slot(self) -> None:
+        """Positional state is shared machinery — macro types must stay independent."""
+        page = _make_page(
+            body_storage=(
+                _storage_macro("plantuml", "@startuml\nAlice -> Bob\n@enduml")
+                + _storage_macro("digraph", "A -> B")
+            ),
+        )
+        converter = Page.Converter(page)
+
+        graphviz_result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+        plantuml_result = converter.convert_plantuml(
+            _el('<div data-macro-name="plantuml"></div>', "div"), "", []
+        )
+
+        assert "A -> B" in graphviz_result
+        assert "Alice -> Bob" in plantuml_result
+
+
+class TestGraphvizDispatch:
+    """The converter reaches `convert_graphviz` from both div and span macro output."""
+
+    @pytest.fixture(autouse=True)
+    def _settings(self):  # noqa: ANN202
+        with patch("confluence_markdown_exporter.confluence.settings") as mock_settings:
+            mock_settings.export.include_document_title = False
+            mock_settings.export.page_breadcrumbs = False
+            mock_settings.export.convert_text_highlights = False
+            mock_settings.export.convert_font_colors = False
+            mock_settings.export.convert_status_badges = False
+            yield mock_settings
+
+    def test_full_page_conversion(self) -> None:
+        """Both macros resolve, in order, through the whole conversion pipeline."""
+        page = _make_page(
+            body_storage=(
+                _storage_macro(
+                    "digraph",
+                    "A -> B",
+                    params='<ac:parameter ac:name="attributes">rankdir=LR;</ac:parameter>',
+                )
+                + _storage_macro("graphviz", "digraph Full {\n  X -> Y;\n}")
+            ),
+        )
+        html = (
+            "<p>Before</p>"
+            '<div class="conf-macro output-block" data-hasbody="true" data-macro-name="digraph">'
+            '<img src="/download/attachments/1/graph.png" alt="digraph"/></div>'
+            "<p>Between</p>"
+            '<div class="conf-macro output-block" data-hasbody="true" data-macro-name="graphviz">'
+            '<img src="/download/attachments/1/graph2.png"/></div>'
+        )
+        page.html = html
+
+        result = Page.Converter(page).convert(html)
+
+        assert "digraph G {\nrankdir=LR;\nA -> B\n}" in result
+        assert "digraph Full {\n  X -> Y;\n}" in result
+        # The rendered preview images the macros produce are replaced, not kept alongside.
+        assert "graph.png" not in result
+        assert "graph2.png" not in result
+
+    @pytest.mark.parametrize("macro_name", ["graphviz", "digraph"])
+    def test_convert_div_dispatches(self, macro_name: str) -> None:
+        page = _make_page(body_storage=_storage_macro(macro_name, "digraph G { A -> B }"))
+        converter = Page.Converter(page)
+
+        html = (
+            f'<div class="conf-macro output-block" data-hasbody="true" '
+            f'data-macro-name="{macro_name}"><img src="graph.png"/></div>'
+        )
+        result = converter.convert_div(_el(html, "div"), "", [])
+
+        assert "```dot" in result
+        assert "A -> B" in result
+
+    @pytest.mark.parametrize("macro_name", ["graphviz", "digraph"])
+    def test_convert_span_dispatches(self, macro_name: str) -> None:
+        page = _make_page(body_storage=_storage_macro(macro_name, "digraph G { A -> B }"))
+        converter = Page.Converter(page)
+
+        html = (
+            f'<span class="conf-macro output-inline" data-hasbody="true" '
+            f'data-macro-name="{macro_name}"><img src="graph.png"/></span>'
+        )
+        result = converter.convert_span(_el(html, "span"), "", [])
+
+        assert "```dot" in result
+        assert "A -> B" in result
+
+    def test_missing_source_emits_comment(self) -> None:
+        converter = Page.Converter(_make_page())
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert "<!-- Graphviz diagram" in result
+        assert "source not found" in result
+
+    def test_empty_body_emits_comment(self) -> None:
+        page = _make_page(body_storage=_storage_macro("digraph", ""))
+        converter = Page.Converter(page)
+
+        result = converter.convert_graphviz(
+            _el('<div data-macro-name="digraph"></div>', "div"), "", []
+        )
+
+        assert "source not found" in result
+
+
+class TestDotCodeBlockDetection:
+    """Auto-detection of DOT source in plain `<pre>` code blocks."""
+
+    @pytest.fixture(autouse=True)
+    def _settings(self):  # noqa: ANN202
+        with patch("confluence_markdown_exporter.confluence.settings") as mock_settings:
+            mock_settings.export.include_document_title = False
+            yield mock_settings
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "digraph G {\n  A -> B;\n}",
+            "digraph {\n  A -> B;\n}",
+            "strict digraph G {\n  A -> B;\n}",
+            "graph G {\n  A -- B;\n}",
+            "  DiGraph Foo {\n  A -> B;\n}",
+            "digraph{A->B}",
+            'digraph "my graph" {\n  A -> B;\n}',
+        ],
+    )
+    def test_dot_source_gets_dot_fence(self, text: str) -> None:
+        converter = Page.Converter(_make_page())
+
+        result = converter.convert_pre(_el("<pre></pre>", "pre"), text, [])
+
+        assert "```dot" in result
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "// a comment\ndigraph G {\n  A -> B;\n}",
+            "/* a comment */\ndigraph G {\n  A -> B;\n}",
+            "# a comment\ndigraph G {\n  A -> B;\n}",
+        ],
+    )
+    def test_leading_comments_are_skipped(self, text: str) -> None:
+        converter = Page.Converter(_make_page())
+
+        result = converter.convert_pre(_el("<pre></pre>", "pre"), text, [])
+
+        assert "```dot" in result
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "graph TD\n  A-->B",
+            "graph LR;\n  A-->B",
+            "flowchart TD\n  A-->B",
+        ],
+    )
+    def test_mermaid_flowchart_is_not_detected_as_dot(self, text: str) -> None:
+        """Mermaid's `graph TD` has no brace on the header line — it must not match."""
+        converter = Page.Converter(_make_page())
+
+        result = converter.convert_pre(_el("<pre></pre>", "pre"), text, [])
+
+        assert "```dot" not in result
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "graph = {\n    'a': ['b'],\n}",
+            "digraph = {}",
+            "graph: Dict[str, int] = {}",
+            "const graph = { a: 1 };",
+            "subgraph cluster_0 {\n}",
+        ],
+    )
+    def test_code_declaring_a_graph_variable_is_not_detected_as_dot(self, text: str) -> None:
+        """DOT allows only an optional ID between the keyword and the brace.
+
+        A wider gap would swallow ordinary code that happens to assign a variable
+        named `graph` or `digraph`.
+        """
+        converter = Page.Converter(_make_page())
+
+        result = converter.convert_pre(_el("<pre></pre>", "pre"), text, [])
+
+        assert "```dot" not in result
+
+    def test_declared_language_wins_over_dot_detection(self) -> None:
+        """A declared brush language is stronger evidence than a `graph` keyword."""
+        converter = Page.Converter(_make_page())
+
+        html = '<pre data-syntaxhighlighter-params="brush: java; gutter: false"></pre>'
+        result = converter.convert_pre(_el(html, "pre"), "graph G {\n  int x = 1;\n}", [])
+
+        assert "```java" in result
+        assert "```dot" not in result
+
+    def test_startuml_still_wins(self) -> None:
+        converter = Page.Converter(_make_page())
+
+        result = converter.convert_pre(
+            _el("<pre></pre>", "pre"), "@startuml\ndigraph G {}\n@enduml", []
+        )
+
+        assert "```plantuml" in result
+        assert "```dot" not in result
+
+    def test_unrelated_code_keeps_empty_language(self) -> None:
+        converter = Page.Converter(_make_page())
+
+        result = converter.convert_pre(_el("<pre></pre>", "pre"), "print('hello')", [])
+
+        assert "```dot" not in result
+        assert result.startswith("\n\n```\n")


### PR DESCRIPTION
## Summary

Adds conversion for the [Graphviz Diagrams for Confluence](https://marketplace.atlassian.com/apps/257/graphviz-diagrams-for-confluence) app's `graphviz` and `digraph` macros, so Graphviz diagrams survive an export the way PlantUML and draw.io-embedded Mermaid already do. Today they're dropped (only the rendered preview image is left behind).

| Confluence | Markdown |
|---|---|
| `graphviz` macro (body is a complete DOT document) | emitted verbatim in a ` ```dot ` fence |
| `digraph` macro (body is statements only) | graph header reconstructed, then fenced |
| Code macro holding DOT source with no declared language | fenced as `dot` |

The `digraph` macro is the substantive case. Its body holds only the statements (`A -> B`) because the plugin supplies the `digraph G { … }` header when rendering, so exporting the body as-is yields DOT that won't render. The header is rebuilt from the macro's `name` and `attributes` parameters:

```dot
digraph G {
rankdir=LR;
A -> B
}
```

Everything that reconstruction touches is aimed at emitting DOT that actually parses:

- A body that already carries its own header isn't wrapped again — including when it opens with a `//`, `#`, or `/* */` comment, since nesting `digraph` inside `digraph` is a syntax error (only `subgraph` may nest).
- A `name` that is a DOT reserved word (`graph`, `node`, `edge`, …) or isn't a bare identifier gets quoted; `digraph graph {` doesn't parse.
- `attributes` written as a Graphviz attribute list (`rankdir=LR, size="8,5"`) has its top-level commas rewritten to semicolons, because a comma isn't a valid statement separator at graph level. Commas inside quoted values are preserved, and a value already using semicolons passes through untouched.

Statements are emitted verbatim rather than re-indented, deliberately: DOT permits backslash-continued quoted strings and HTML-like `label=<…>` values whose content would change if leading whitespace were added.

### Source lookup

Mirrors `convert_plantuml`: editor2 XML by `macro-id` (Cloud) first, then positional matching against `body.storage` (Server / Data Center, where the view HTML carries no `macro-id`). Unlike PlantUML the body is raw DOT rather than a JSON envelope.

To share that machinery, the PlantUML-specific storage cache and position counter are generalised to be keyed by macro name (`_storage_macros` / `_next_storage_macro` / `_editor2_macro`). Without that, a `graphviz` macro would consume a `digraph` macro's positional slot. **PlantUML behaviour is unchanged** — its existing tests pass untouched. The parsed editor2 soup is now cached rather than reparsed once per macro, which also takes a little work off pages with many PlantUML diagrams.

`convert_graphviz` consumes its storage slot unconditionally, before trying editor2, so a page where editor2 resolves some diagrams but not others can't silently pair later diagrams with earlier sources. `convert_plantuml` still has that latent drift — I left it alone rather than change behaviour I can't exercise against a real Cloud page, but it's worth a look independently of this PR.

### Code-block detection

`convert_pre` already relabels any block containing `@startuml` as `plantuml`. DOT detection is deliberately much stricter, because the `graph` keyword is ambiguous in two directions:

- Only an optional graph ID is allowed between the keyword and the brace — exactly what DOT's grammar permits. A wider gap would swallow ordinary code assigning a variable named `graph` or `digraph` (`graph = {...}`, `graph: Dict[str, int] = {}`, `const graph = { a: 1 };`).
- The brace has to sit on the header line, which keeps Mermaid's `graph TD` / `graph LR` from being read as DOT.
- It only applies when the Code macro declared no `brush` language, since an explicit language is stronger evidence than a `graph` keyword.

## Test Plan

`tests/unit/test_graphviz_conversion.py` — 54 new tests, structured after the existing `test_plantuml_conversion.py` / `test_plantuml_code_block_detection.py`:

- **`graphviz` macro**: body emitted verbatim; editor2-by-macro-id; editor2 miss falling back to storage; undirected `graph G { a -- b }` untouched
- **`digraph` macro**: header reconstruction; `name` parameter; non-bare and reserved-word names quoted; `attributes` comma-list normalised and semicolon form preserved; already-headered body not double-wrapped (bare and with each comment style); line-continued string not re-indented
- **Positional matching**: multiple `digraph`s in order; `graphviz` not consuming `digraph`'s slot; `digraph` not consuming PlantUML's slot; editor2 hit still advancing the storage position
- **Dispatch**: `convert_div` and `convert_span`, parametrized over both macro names; a full-page `Converter.convert()` run asserting the preview `<img>` is replaced rather than left alongside; missing and empty source both emitting the fallback comment
- **`<pre>` detection**: 7 positive DOT forms and 3 comment-prefixed ones; 3 Mermaid forms and 5 graph-variable-assignment forms that must *not* match; declared `brush` language winning; `@startuml` still winning

Full checklist from CONTRIBUTING.md, on Python 3.10.12:

```
uv run ruff check   # All checks passed!
uv run pytest       # 496 passed
uv build --no-sources  # sdist + wheel built
```

## Two things worth your judgement

1. **Fence language is `dot`, not `graphviz`.** `dot` is what GitHub Linguist and the Obsidian Graphviz plugins use; Kroki and some MkDocs setups prefer `graphviz`. Given how much this project targets Obsidian I went with `dot`, but it's a one-line change and I'm happy to switch or make it configurable if you'd rather.
2. **I only claimed `graphviz` and `digraph`.** The app also ships `graph`, `flowchart`, `graph from table` and `space graph`. Undirected `graph` would be a one-line addition to `_GRAPHVIZ_MACROS` (`{"graph": "graph"}`), but `graph` is a generic enough macro name that I didn't want to claim it without a real page to test against. The others need a different approach entirely (table/space traversal rather than a DOT body), so they'd be separate work.

## Where I'd welcome a second pair of eyes

Two parts of this are inferred rather than confirmed against a live instance, and I'd rather flag them than have them discovered later:

- **The Cloud/Connect path is untested against a real page.** The editor2-by-macro-id branch is written by analogy with `convert_plantuml` and is unit-tested, but I had no Cloud instance with this app installed to confirm it renders `data-macro-name` / `data-macro-id` into the view HTML at all. The Server/DC `body.storage` path is the one I'm confident in. If it turns out Cloud renders the macro in an iframe, that branch is simply inert and the fallback comment fires — it shouldn't regress anything, but it also wouldn't help Cloud users.
- **The `attributes` normalisation encodes a guess about the plugin's own template.** The app's parameter documentation is login-walled, so the comma/semicolon rule comes from DOT's grammar rather than from confirming how the plugin splices the value in. If anyone has a page using that parameter, its storage XML would settle it.

Happy to iterate on any of this.
