### PR TITLE
fix(tables): repeat merged cell content across spanned cells

### DIFF
--- a/confluence_markdown_exporter/utils/table_converter.py
+++ b/confluence_markdown_exporter/utils/table_converter.py
@@ -67,9 +67,15 @@ def _get_int_attr(cell: Tag, attr: str, default: str = "1") -> int:
 def pad(rows: list[list[Tag]]) -> list[list[Tag]]:
     """Expand rowspan and colspan into a rectangular grid of cells.
 
-    Markdown tables cannot merge cells, so every grid position a merged cell covers
-    references the merge origin itself and therefore renders the same value. The same
-    Tag object is reused on purpose, so callers can convert each origin only once.
+    Markdown tables cannot merge cells, so in a well-formed table every grid position a
+    merged cell covers references the merge origin itself and therefore renders the same
+    value. The same Tag object is reused on purpose, so callers can convert each origin
+    only once.
+
+    A ragged row, one with too few cells to reach a position reserved by an earlier
+    rowspan, still drops that reservation, because the trailing sweep only fills the
+    positions directly following the last cell of the row. Such markup is malformed and
+    renders the same way it did before merged content was carried over.
     """
     padded: list[list[Tag]] = []
     occ: dict[tuple[int, int], Tag] = {}
@@ -82,8 +88,10 @@ def pad(rows: list[list[Tag]]) -> list[list[Tag]]:
             while (r, c) in occ:
                 cur.append(occ.pop((r, c)))
                 c += 1
-            # Malformed markup can yield 0 (or a negative value); such a cell still
-            # occupies a single grid position.
+            # Every cell occupies at least one grid position: colspan="0" (valid in
+            # HTML4, dropped in HTML5) or a negative value would otherwise erase it.
+            # rowspan="0" validly means "to the end of the row group"; treating it as a
+            # single row is a pragmatic simplification, not a spec-accurate reading.
             rs = max(_get_int_attr(cell, "rowspan", "1"), 1)
             cs = max(_get_int_attr(cell, "colspan", "1"), 1)
             # Repeat the cell across the columns it spans in this row.
@@ -163,6 +171,9 @@ class TableConverter(MarkdownConverter):
         # A merged cell occupies several grid positions but must be converted only
         # once: conversion is stateful (e.g. the PlantUML macro index advances per
         # converted macro), so repeated positions reuse the first conversion.
+        # Keyed on id() and not on the Tag itself: bs4 gives Tag a structural __eq__
+        # and __hash__, so two distinct cells with identical markup would collapse
+        # into one cache entry and wrongly share a conversion.
         cell_cache: dict[int, str] = {}
         converted: list[list[str]] = []
         for row in padded_rows:

--- a/confluence_markdown_exporter/utils/table_converter.py
+++ b/confluence_markdown_exporter/utils/table_converter.py
@@ -65,7 +65,12 @@ def _get_int_attr(cell: Tag, attr: str, default: str = "1") -> int:
 
 
 def pad(rows: list[list[Tag]]) -> list[list[Tag]]:
-    """Pad table rows to handle rowspan and colspan for markdown conversion."""
+    """Expand rowspan and colspan into a rectangular grid of cells.
+
+    Markdown tables cannot merge cells, so every grid position a merged cell covers
+    references the merge origin itself and therefore renders the same value. The same
+    Tag object is reused on purpose, so callers can convert each origin only once.
+    """
     padded: list[list[Tag]] = []
     occ: dict[tuple[int, int], Tag] = {}
     for r, row in enumerate(rows):
@@ -77,28 +82,22 @@ def pad(rows: list[list[Tag]]) -> list[list[Tag]]:
             while (r, c) in occ:
                 cur.append(occ.pop((r, c)))
                 c += 1
-            rs = _get_int_attr(cell, "rowspan", "1")
-            cs = _get_int_attr(cell, "colspan", "1")
-            cur.append(cell)
-            # Append extra cells for colspan
-            if cs > 1:
-                cur.extend(make_empty_cell() for _ in range(1, cs))
-            # Mark future cells for rowspan and colspan
-            for i in range(rs):
+            # Malformed markup can yield 0 (or a negative value); such a cell still
+            # occupies a single grid position.
+            rs = max(_get_int_attr(cell, "rowspan", "1"), 1)
+            cs = max(_get_int_attr(cell, "colspan", "1"), 1)
+            # Repeat the cell across the columns it spans in this row.
+            cur.extend([cell] * cs)
+            # Reserve the positions it spans in the following rows.
+            for i in range(1, rs):
                 for j in range(cs):
-                    if i or j:
-                        occ[(r + i, c + j)] = make_empty_cell()
+                    occ[(r + i, c + j)] = cell
             c += cs
         while (r, c) in occ:
             cur.append(occ.pop((r, c)))
             c += 1
         padded.append(cur)
     return padded
-
-
-def make_empty_cell() -> Tag:
-    """Return an empty <td> Tag."""
-    return Tag(name="td")
 
 
 def normalize_table_cell_text(text: str) -> str:
@@ -161,9 +160,18 @@ class TableConverter(MarkdownConverter):
             return ""
 
         padded_rows = pad(rows)
-        converted = [
-            [self.process_tag(cell, parent_tags={"table"}) for cell in row] for row in padded_rows
-        ]
+        # A merged cell occupies several grid positions but must be converted only
+        # once: conversion is stateful (e.g. the PlantUML macro index advances per
+        # converted macro), so repeated positions reuse the first conversion.
+        cell_cache: dict[int, str] = {}
+        converted: list[list[str]] = []
+        for row in padded_rows:
+            converted_row: list[str] = []
+            for cell in row:
+                if id(cell) not in cell_cache:
+                    cell_cache[id(cell)] = self.process_tag(cell, parent_tags={"table"})
+                converted_row.append(cell_cache[id(cell)])
+            converted.append(converted_row)
 
         has_header = all(cell.name == "th" for cell in rows[0])
 

--- a/tests/unit/utils/test_table_converter.py
+++ b/tests/unit/utils/test_table_converter.py
@@ -1,8 +1,24 @@
 """Tests for the table_converter module."""
 
+from typing import Any
+
 from bs4 import BeautifulSoup
 
 from confluence_markdown_exporter.utils.table_converter import TableConverter
+
+
+class _CountingTableConverter(TableConverter):
+    """TableConverter that records the cells ``convert_table`` converts."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        super().__init__(*args, **kwargs)
+        self.converted_cell_ids: list[int] = []
+
+    def process_tag(self, node: Any, *args: Any, **kwargs: Any) -> str:  # noqa: ANN401
+        parent_tags = kwargs.get("parent_tags", args[0] if args else None)
+        if getattr(node, "name", None) in {"td", "th"} and parent_tags == {"table"}:
+            self.converted_cell_ids.append(id(node))
+        return super().process_tag(node, *args, **kwargs)  # type: ignore[no-any-return]
 
 
 class TestTableConverter:
@@ -313,3 +329,131 @@ class TestTableConverter:
         result = converter.convert(html)
         # Should be formatted compactly
         assert "  " not in result
+
+
+class TestMergedCells:
+    """Markdown has no merged cells, so a span repeats its value in every position."""
+
+    @staticmethod
+    def _convert(html: str) -> list[str]:
+        """Convert compactly and return the table rows."""
+        converter = TableConverter(table_column_width="compact")
+        return [line for line in converter.convert(html).splitlines() if line.startswith("|")]
+
+    def test_rowspan_repeats_value_in_following_row(self) -> None:
+        """A rowspan=2 cell must render its value in both rows."""
+        html = """
+        <table>
+            <tr><th>Env</th><th>Branch</th><th>Cluster</th></tr>
+            <tr><td>Staging</td><td>release</td><td rowspan="2">Cluster A</td></tr>
+            <tr><td>Test</td><td>main</td></tr>
+        </table>
+        """
+        assert self._convert(html) == [
+            "| Env | Branch | Cluster |",
+            "| --- | --- | --- |",
+            "| Staging | release | Cluster A |",
+            "| Test | main | Cluster A |",
+        ]
+
+    def test_rowspan_three_repeats_in_all_rows(self) -> None:
+        """A rowspan larger than two must fill every covered row."""
+        html = """
+        <table>
+            <tr><th>H1</th><th>H2</th></tr>
+            <tr><td rowspan="3">Shared</td><td>a</td></tr>
+            <tr><td>b</td></tr>
+            <tr><td>c</td></tr>
+        </table>
+        """
+        assert self._convert(html)[2:] == [
+            "| Shared | a |",
+            "| Shared | b |",
+            "| Shared | c |",
+        ]
+
+    def test_colspan_repeats_value_across_columns(self) -> None:
+        """A colspan=3 cell must render its value in all three columns."""
+        html = """
+        <table>
+            <tr><th>H1</th><th>H2</th><th>H3</th></tr>
+            <tr><td colspan="3">Full width</td></tr>
+        </table>
+        """
+        assert self._convert(html)[2:] == ["| Full width | Full width | Full width |"]
+
+    def test_rowspan_and_colspan_fill_whole_block(self) -> None:
+        """A combined rowspan/colspan cell must fill the full 2x2 block."""
+        html = """
+        <table>
+            <tr><th>H1</th><th>H2</th><th>H3</th></tr>
+            <tr><td>a</td><td rowspan="2" colspan="2">Block</td></tr>
+            <tr><td>b</td></tr>
+        </table>
+        """
+        assert self._convert(html)[2:] == [
+            "| a | Block | Block |",
+            "| b | Block | Block |",
+        ]
+
+    def test_rowspan_on_header_cell(self) -> None:
+        """A rowspan on a header cell repeats into the row below it."""
+        html = """
+        <table>
+            <tr><th rowspan="2">Name</th><th>A</th></tr>
+            <tr><th>B</th></tr>
+            <tr><td>x</td><td>y</td></tr>
+        </table>
+        """
+        assert self._convert(html) == [
+            "| Name | A |",
+            "| --- | --- |",
+            "| Name | B |",
+            "| x | y |",
+        ]
+
+    def test_cells_after_a_span_keep_their_column(self) -> None:
+        """A span in the first column must not shift the following cells."""
+        html = """
+        <table>
+            <tr><th>H1</th><th>H2</th><th>H3</th></tr>
+            <tr><td rowspan="2">R</td><td>b1</td><td>c1</td></tr>
+            <tr><td>b2</td><td>c2</td></tr>
+        </table>
+        """
+        assert self._convert(html)[2:] == [
+            "| R | b1 | c1 |",
+            "| R | b2 | c2 |",
+        ]
+
+    def test_malformed_span_attributes_keep_cells(self) -> None:
+        """Unparsable or zero span values must fall back to a single cell."""
+        html = """
+        <table>
+            <tr><th>H1</th><th>H2</th></tr>
+            <tr><td colspan="abc">A</td><td rowspan="0">B</td></tr>
+        </table>
+        """
+        assert self._convert(html)[2:] == ["| A | B |"]
+
+    def test_spanned_cell_is_converted_only_once(self) -> None:
+        """Repeated positions must reuse the conversion, not run it again.
+
+        Cell conversion is stateful in ``Page.Converter`` (the PlantUML macro index
+        advances per converted macro), so a repeated cell must not be reprocessed.
+        """
+        html = """
+        <table>
+            <tr><th>H1</th><th>H2</th></tr>
+            <tr><td rowspan="3">Shared</td><td>a</td></tr>
+            <tr><td>b</td></tr>
+            <tr><td>c</td></tr>
+        </table>
+        """
+        converter = _CountingTableConverter(table_column_width="compact")
+        converter.convert(html)
+
+        ids = converter.converted_cell_ids
+        assert len(ids) == len(set(ids)), "a cell was converted more than once"
+        # 2 headers + 1 spanned cell + 3 regular cells.
+        assert len(ids) == 6

--- a/tests/unit/utils/test_table_converter.py
+++ b/tests/unit/utils/test_table_converter.py
@@ -436,6 +436,27 @@ class TestMergedCells:
         """
         assert self._convert(html)[2:] == ["| A | B |"]
 
+    def test_zero_or_negative_colspan_keeps_the_cell(self) -> None:
+        """A colspan below 1 must still occupy one position instead of erasing the cell.
+
+        This is what the minimum of 1 in ``pad`` protects: without it the cell is
+        repeated zero times and disappears from the row.
+        """
+        zero = """
+        <table>
+            <tr><th>H1</th><th>H2</th></tr>
+            <tr><td colspan="0">A</td><td>B</td></tr>
+        </table>
+        """
+        negative = """
+        <table>
+            <tr><th>H1</th><th>H2</th></tr>
+            <tr><td colspan="-1">A</td><td>B</td></tr>
+        </table>
+        """
+        assert self._convert(zero)[2:] == ["| A | B |"]
+        assert self._convert(negative)[2:] == ["| A | B |"]
+
     def test_spanned_cell_is_converted_only_once(self) -> None:
         """Repeated positions must reuse the conversion, not run it again.
 
@@ -455,5 +476,7 @@ class TestMergedCells:
 
         ids = converter.converted_cell_ids
         assert len(ids) == len(set(ids)), "a cell was converted more than once"
-        # 2 headers + 1 spanned cell + 3 regular cells.
+        # 2 headers + 1 spanned cell + 3 regular cells. This counts only the pass
+        # convert_table performs itself; markdownify's own tree descent converts every
+        # cell once more, which is pre-existing behaviour and out of scope here.
         assert len(ids) == 6


### PR DESCRIPTION
Closes #292

## What

Merged Confluence table cells (`rowspan` / `colspan`) now repeat their value in every grid position the merge covers, instead of exporting blank cells.

Before:

```markdown
| Env | Branch | Cluster |
| --- | --- | --- |
| Staging | release | Cluster A |
| Test | main |  |
```

After:

```markdown
| Env | Branch | Cluster |
| --- | --- | --- |
| Staging | release | Cluster A |
| Test | main | Cluster A |
```

## Why

Markdown pipe tables have no merged cells, so `pad()` expands each table into a rectangular grid. It filled every position covered by a span with a freshly created empty `<td>` (`make_empty_cell()`), so the geometry was right but the content survived only in the merge origin. Every other covered row or column exported as blank, silently dropping data that is plainly visible in Confluence.

Repeating the value is the most faithful representation available in GFM and keeps each row self-contained, which matters for the row-oriented tools people use on exported Markdown (grep, Dataview queries, spreadsheet imports).

### Trade-off on horizontal merges

Note that `colspan` never actually lost data before this change: the old code emitted the value once and padded the rest of the row with blanks. It is included here so that one rule covers both merge directions, but it does change output, and there is a cost worth calling out explicitly.

A full-width section row is now printed once per column, and because the repeated text widens the row, a `mixed` mode table can cross `_MAX_TABLE_LINE_LEN` and fall back to compact formatting. Measured on a 4-column table with a full-width section row: a short title keeps the table aligned at 58 characters, while `Non-production environments` reaches 121 characters and flips the whole table to compact.

```markdown
| **Env** | **Branch** | **Cluster** | **Owner** |
| --- | --- | --- | --- |
| Non-production environments | Non-production environments | Non-production environments | Non-production environments |
| Dev | development | Cluster A | Team 1 |
```

Vertical merges never have this effect, since they add no width. If you would rather keep `colspan` as it was, or repeat it only when the cell does not span the entire row, that is a small change to `pad()` and I am happy to adjust.

## How

- `pad()` fills spanned positions with the merge **origin `Tag` object itself** rather than a new empty cell.
- `convert_table()` memoizes `process_tag` per cell object, so a merged cell is converted exactly once no matter how many positions it covers. This is required, not an optimisation: cell conversion is stateful, and `_extract_uml_from_storage` advances `self._plantuml_index` on every converted PlantUML macro, so converting a repeated cell again would misalign every later diagram on the page.
- `rowspan` / `colspan` are clamped to a minimum of `1`. This is what stops `colspan="0"` (valid in HTML4, dropped in HTML5) or a negative value from repeating the cell zero times and erasing it from the row. `rowspan="0"` validly means "to the end of the row group"; treating it as a single row is a pragmatic simplification rather than a spec-accurate reading.
- The occupancy loop starts at `i = 1`; the `i == 0` entries it used to write were same-row positions the column cursor had already passed, so they were never read.
- `make_empty_cell()` is removed, since `pad()` was its only caller.

Tables without merged cells are byte-for-byte unaffected: every cell is a distinct object, so the cache always misses and the conversion sequence is identical to before.

## Tests

The repo had no `rowspan` / `colspan` coverage at all, which is why this went unnoticed. A new `TestMergedCells` class covers:

- `rowspan=2` and `rowspan=3` repeating down the covered rows
- `colspan=3` repeating across the covered columns
- a combined `rowspan=2 colspan=2` block
- `rowspan` on a `<th>` in the header row
- geometry regression: cells following a first-column span keep their column
- unparsable `colspan="abc"` and `rowspan="0"` do not drop cells
- `colspan="0"` and a negative `colspan` do not erase the cell, which is the case that actually pins the clamp
- a merged cell is passed to `process_tag` exactly once

Assertions compare whole rows in `compact` mode, so column order and column count are verified, not just substring presence.

## Verification

- `uv run pytest`: 451 passed. 7 of the 9 new tests fail on `main`, confirming the regression they pin down, and the zero/negative `colspan` test fails if the clamp is removed
- `uv run ruff check .`: clean; `ruff format --check` clean for both changed files
- End-to-end export of a real Confluence Cloud page containing a 5-column table with two cells merged across two rows: the previously blank cells now carry the merged values, and the unmerged rows are unchanged
- Horizontal merges checked separately against the markup Confluence Cloud actually emits (`<colgroup>`, `<tbody>`, `confluenceTd` classes, `<p>`-wrapped cell content), in both `compact` and `mixed` mode: partial `colspan`, `colspan` in the header row, two `colspan` cells in one row, `colspan` combined with `rowspan`, and a `colspan` wider than the header row (truncated to the header's column count, which loses nothing because every copy is identical)
