### PR TITLE
build(deps): cap atlassian-python-api below 5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,11 @@ authors = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    'atlassian-python-api',
+    # atlassian-python-api 5.x is a breaking rewrite of the Confluence client:
+    # the Cloud class drops get_page_by_id, get_attachments_from_content and
+    # get_page_comments, client.url no longer carries the /wiki context, and the
+    # v2 cursor pagination builds an invalid next-page URL. Cap until we migrate.
+    'atlassian-python-api>=4,<5',
     'jmespath',
     'markdownify',
     'pydantic-settings',

--- a/uv.lock
+++ b/uv.lock
@@ -238,7 +238,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "atlassian-python-api" },
+    { name = "atlassian-python-api", specifier = ">=4,<5" },
     { name = "jmespath" },
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "markdownify" },


### PR DESCRIPTION
Fixes #296

### What

Cap `atlassian-python-api` to `>=4,<5` in `pyproject.toml` and record the specifier in `uv.lock`. No code changes.

### Why

`atlassian-python-api` 5.0.0 was released on 2026-08-15 and is a breaking rewrite of the Confluence client. Because the dependency had no upper bound, every fresh install of cme (including pinned installs of 5.3.0) now resolves to 5.x and fails at the first Confluence call. The lockfile in this repository still pins 4.0.7, so CI does not see the breakage, but users installing from PyPI do.

What 5.x changes for cme, measured on `Confluence(url=..., cloud=True)` with the HTTP layer stubbed:

- `client.url` no longer carries the `/wiki` context, which breaks the raw v1 REST calls in `_fetch_page_ids_cql_batch` and `_fetch_comment_replies` and the attachment download that builds `client.url + download_link`.
- `get_page_by_id`, `get_attachments_from_content` and `get_page_comments` no longer exist on the Cloud class.
- `get_all_spaces` serves the v2 endpoint and ignores the v1 `space_type` / `space_status` / `expand` arguments used by `Organization.from_url`.
- Its v2 cursor pagination joins the relative `_links.next` onto a base that already ends in `/wiki`, requesting `/wiki/wiki/api/v2/spaces` and getting a 404. That is the error users hit first, in the connection check in `ApiClientFactory.create_confluence`.

The cap restores the dependency set that the lockfile already uses and that every working install has. It can be lifted once cme is migrated to the 5.x client, which is a larger piece of work: the v2 API has no CQL equivalent, so part of the v1 usage has to stay in any case.

### Verification

- `uv lock --check` passes with no re-resolution.
- `uv run pytest` passes (442 tests).
- `uv tool install confluence-markdown-exporter==5.3.0 --with "atlassian-python-api<5"` resolves `atlassian-python-api==4.0.7` and the export runs green again, which is the same constraint this PR encodes in the package metadata.
