### PR TITLE
feat(attachment_path): add page_id/page_title template variables for attachments

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -737,6 +737,12 @@ class Attachment(Document):
     collection_name: str
     download_link: str
     comment: str
+    # Populated by from_page_id()/from_json() from the owning page - Document itself has no
+    # page context (only space/homepage/ancestors), unlike Page/Descendant which add page_id/
+    # page_title on top. Kept optional (empty string default) for backward compatibility with
+    # any other from_json() call site that does not know the owning page.
+    page_id: str = ""
+    page_title: str = ""
 
     @property
     def extension(self) -> str:
@@ -758,6 +764,8 @@ class Attachment(Document):
         title_without_ext = title[: -len(ext)] if ext and title.endswith(ext) else Path(title).stem
         return {
             **super()._template_vars,
+            "page_id": self.page_id,
+            "page_title": sanitize_filename(self.page_title) if self.page_title else "",
             "attachment_id": str(self.id),
             "attachment_title": sanitize_filename(title_without_ext),
             # file_id is a GUID and does not need sanitization. On
@@ -774,7 +782,9 @@ class Attachment(Document):
         return Path(filepath_template.safe_substitute(self._template_vars))
 
     @classmethod
-    def from_json(cls, data: JsonResponse, base_url: str) -> "Attachment":
+    def from_json(
+        cls, data: JsonResponse, base_url: str, *, page_id: str = "", page_title: str = ""
+    ) -> "Attachment":
         extensions = data.get("extensions", {})
         container = data.get("container", {})
         return cls(
@@ -791,6 +801,8 @@ class Attachment(Document):
             collection_name=extensions.get("collectionName", ""),
             download_link=data.get("_links", {}).get("download", ""),
             comment=extensions.get("comment", ""),
+            page_id=page_id,
+            page_title=page_title,
             ancestors=[
                 *[
                     Ancestor.from_json(ancestor, base_url)
@@ -802,7 +814,9 @@ class Attachment(Document):
         )
 
     @classmethod
-    def from_page_id(cls, page_id: int, base_url: str) -> list["Attachment"]:
+    def from_page_id(
+        cls, page_id: int, base_url: str, page_title: str = ""
+    ) -> list["Attachment"]:
         attachments = []
         start = 0
         paging_limit = 50
@@ -820,7 +834,12 @@ class Attachment(Document):
             )
 
             attachments.extend(
-                [cls.from_json(att, base_url) for att in response.get("results", [])]
+                [
+                    cls.from_json(
+                        att, base_url, page_id=str(page_id), page_title=page_title
+                    )
+                    for att in response.get("results", [])
+                ]
             )
 
             size = response.get("size", 0)
@@ -1372,7 +1391,9 @@ class Page(Document):
                 Label.from_json(label)
                 for label in data.get("metadata", {}).get("labels", {}).get("results", [])
             ],
-            attachments=Attachment.from_page_id(data.get("id", 0), base_url),
+            attachments=Attachment.from_page_id(
+                data.get("id", 0), base_url, page_title=data.get("title", "")
+            ),
             ancestors=[
                 Ancestor.from_json(ancestor, base_url) for ancestor in data.get("ancestors", [])
             ][1:],

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -391,6 +391,8 @@ class ExportConfig(BaseModel):
             "  - {homepage_title}: The title of the homepage of the Confluence space.\n"
             "  - {ancestor_ids}: A slash-separated list of ancestor page IDs.\n"
             "  - {ancestor_titles}: A slash-separated list of ancestor page titles.\n"
+            "  - {page_id}: The unique ID of the Confluence page the attachment is on.\n"
+            "  - {page_title}: The title of the Confluence page the attachment is on.\n"
             "  - {attachment_id}: The unique ID of the attachment.\n"
             "  - {attachment_title}: The title of the attachment (without file extension).\n"
             "  - {attachment_file_id}: The file ID of the attachment. Falls back to "

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -6,6 +6,7 @@ import logging
 import types
 from pathlib import Path
 from types import SimpleNamespace
+from typing import ClassVar
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -1906,6 +1907,105 @@ class TestAttachmentTemplateVars:
             path2 = att2.export_path
 
         assert path1 != path2
+
+
+class TestAttachmentPageContext:
+    """Attachments carry page_id/page_title from their owning page for page-scoped paths."""
+
+    _SPACE = Space(
+        base_url="https://example.com", key="TS", name="Test", description="", homepage=0
+    )
+
+    _ATTACHMENT_JSON: ClassVar[dict] = {
+        "id": "att-1",
+        "title": "file.png",
+        "extensions": {"fileId": "guid-1"},
+        "_expandable": {"space": "/rest/api/space/TS"},
+        "_links": {"download": "/download/att-1"},
+        "container": {},
+    }
+
+    def test_from_json_without_page_context_defaults_to_empty(self) -> None:
+        """Backward compatible: page_id/page_title default to '' when not passed."""
+        with patch(
+            "confluence_markdown_exporter.confluence.Space.from_key", return_value=self._SPACE
+        ):
+            attachment = Attachment.from_json(self._ATTACHMENT_JSON, "https://example.com")
+
+        assert attachment.page_id == ""
+        assert attachment.page_title == ""
+        assert attachment._template_vars["page_id"] == ""
+        assert attachment._template_vars["page_title"] == ""
+
+    def test_from_json_sets_page_context_when_provided(self) -> None:
+        with patch(
+            "confluence_markdown_exporter.confluence.Space.from_key", return_value=self._SPACE
+        ):
+            attachment = Attachment.from_json(
+                self._ATTACHMENT_JSON, "https://example.com", page_id="42", page_title="My Page"
+            )
+
+        assert attachment.page_id == "42"
+        assert attachment.page_title == "My Page"
+        assert attachment._template_vars["page_id"] == "42"
+        assert attachment._template_vars["page_title"] == "My Page"
+
+    def test_from_page_id_propagates_page_context_to_attachments(self) -> None:
+        fake_response = {"results": [self._ATTACHMENT_JSON], "size": 1}
+        with (
+            patch("confluence_markdown_exporter.confluence.get_thread_confluence") as mock_client,
+            patch(
+                "confluence_markdown_exporter.confluence.Space.from_key", return_value=self._SPACE
+            ),
+        ):
+            mock_client.return_value.get_attachments_from_content.return_value = fake_response
+            attachments = Attachment.from_page_id(42, "https://example.com", page_title="My Page")
+
+        assert len(attachments) == 1
+        assert attachments[0].page_id == "42"
+        assert attachments[0].page_title == "My Page"
+
+    def test_page_from_json_forwards_its_title_as_attachment_page_title(self) -> None:
+        """Page.from_json() must pass its own title through to Attachment.from_page_id()."""
+        page_data = {
+            "id": 42,
+            "title": "My Page",
+            "_expandable": {"space": "/rest/api/space/TS"},
+            "body": {
+                "view": {"value": ""},
+                "export_view": {"value": ""},
+                "editor2": {"value": ""},
+            },
+            "metadata": {"labels": {"results": []}},
+            "ancestors": [],
+            "version": {},
+        }
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.Attachment.from_page_id",
+                return_value=[],
+            ) as mock_from_page_id,
+            patch(
+                "confluence_markdown_exporter.confluence.Space.from_key", return_value=self._SPACE
+            ),
+        ):
+            Page.from_json(page_data, "https://example.com")
+
+        mock_from_page_id.assert_called_once_with(42, "https://example.com", page_title="My Page")
+
+    def test_page_scoped_attachment_path_template(self) -> None:
+        """attachment_path can now use {page_id}/{page_title}, per attachment."""
+        attachment = _make_attachment("123", "guid-1")
+        attachment.page_id = "42"
+        attachment.page_title = "My Page"
+
+        with patch("confluence_markdown_exporter.confluence.settings") as mock_settings:
+            mock_settings.export.attachment_path = (
+                "{page_id}/{attachment_file_id}{attachment_extension}"
+            )
+            path = attachment.export_path
+
+        assert path == Path("42/guid-1.png")
 
 
 class TestWikiLinkDisambiguation:


### PR DESCRIPTION
### Problem

Attachment metadata currently only exposes space/homepage/ancestor context (inherited from `Document`), unlike `Page`/`Descendant` which also expose `page_id`/`page_title`. This makes it impossible to organize attachments per-page using the `export.attachment_path` template.

### Solution

Extended `Attachment` model to accept and expose `page_id` and `page_title` as optional template variables:

- `Attachment._template_vars` now includes `{page_id}` and `{page_title}`
- `Attachment.from_json()` and `Attachment.from_page_id()` accept optional page context
- `Page.from_json()` forwards page metadata when creating attachments
- Backward compatible: defaults to empty strings

### Changes

- `confluence.py`: Extended `Attachment` class with `page_id`/`page_title` fields and updated constructor chain
- `app_data_store.py`: Added documentation for new template variables

Resolves #302