### PR TITLE
fix(emoticons): add Server/DC emoticon support (issue #299)

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2434,10 +2434,49 @@ class Page(Document):
             "atlassian-wink": "😉",
         }
 
+        # Mapping of Confluence Server/DC emoticon names to emoji Unicode values
+        _EMOTICON_SERVERDC_NAMES: ClassVar[dict[str, str]] = {
+            "tick": "✅",
+            "cross": "❌",
+            "check_mark": "✅",
+            "cross_mark": "❌",
+            "yes": "👍",
+            "no": "👎",
+            "thumbs-up": "👍",
+            "thumbs-down": "👎",
+            "info": "\u2139\ufe0f",
+            "information": "\u2139\ufe0f",
+            "warning": "⚠️",
+            "forbidden": "🚫",
+            "add": "\u2795",
+            "plus": "\u2795",
+            "subtract": "\u2796",
+            "minus": "\u2796",
+            "help": "❓",
+            "question": "❓",
+            "attention": "❗",
+            "exclamation": "❗",
+            "light-on": "💡",
+            "light-off": "💡",
+            "light_on": "💡",
+            "light_off": "💡",
+            "light-bulb": "💡",
+            "star": "⭐",
+            "star_yellow": "⭐",
+            "blue_star": "🔵",
+            "smile": "😊",
+            "sad": "😞",
+            "tongue": "😛",
+            "biggrin": "😁",
+            "wink": "😉",
+        }
+
         def _convert_emoticon(self, el: BeautifulSoup) -> str | None:
             classes = el.get("class") or []
             if "emoticon" not in classes:
                 return None
+
+            # Try Cloud format first (data-emoji-id, data-emoji-fallback, etc.)
             emoji_id = str(el.get("data-emoji-id", ""))
             fallback = str(el.get("data-emoji-fallback", ""))
             if fallback and not fallback.startswith(":"):
@@ -2452,6 +2491,12 @@ class Page(Document):
                 if emoji_id in self._ATLASSIAN_EMOTICONS:
                     return self._ATLASSIAN_EMOTICONS[emoji_id]
             shortname = str(el.get("data-emoji-shortname", ""))
+
+            # Fallback to Server/DC format (data-emoticon-name)
+            emoticon_name = str(el.get("data-emoticon-name", ""))
+            if emoticon_name and emoticon_name in self._EMOTICON_SERVERDC_NAMES:
+                return self._EMOTICON_SERVERDC_NAMES[emoticon_name]
+
             return shortname or fallback or str(el.get("alt", "")) or None
 
         def convert_img(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:  # noqa: C901, PLR0911, PLR0912

--- a/tests/unit/test_emoticon_conversion.py
+++ b/tests/unit/test_emoticon_conversion.py
@@ -136,7 +136,9 @@ class TestEmoticonConversion:
         )
         assert converter.convert(html).strip() == "👍"
 
-    def test_serverdc_emoticon_fallback_to_alt_when_name_unknown(self, converter: Page.Converter) -> None:
+    def test_serverdc_emoticon_fallback_to_alt_when_name_unknown(
+        self, converter: Page.Converter
+    ) -> None:
         html = (
             '<img class="emoticon emoticon-unknown"'
             ' data-emoticon-name="unknown_name"'

--- a/tests/unit/test_emoticon_conversion.py
+++ b/tests/unit/test_emoticon_conversion.py
@@ -94,3 +94,53 @@ class TestEmoticonConversion:
         result = converter.convert(html).strip()
         assert "✅" in result
         assert "Done" in result
+
+    # Server/DC format tests (using data-emoticon-name instead of data-emoji-id)
+    def test_serverdc_emoticon_tick(self, converter: Page.Converter) -> None:
+        html = (
+            '<img class="emoticon emoticon-tick"'
+            ' data-emoticon-name="tick"'
+            ' alt="(Häkchen)" />'
+        )
+        assert converter.convert(html).strip() == "✅"
+
+    def test_serverdc_emoticon_cross(self, converter: Page.Converter) -> None:
+        html = (
+            '<img class="emoticon emoticon-cross"'
+            ' data-emoticon-name="cross"'
+            ' alt="(Fehler)" />'
+        )
+        assert converter.convert(html).strip() == "❌"
+
+    def test_serverdc_emoticon_warning(self, converter: Page.Converter) -> None:
+        html = (
+            '<img class="emoticon emoticon-warning"'
+            ' data-emoticon-name="warning"'
+            ' alt="(Warnung)" />'
+        )
+        assert converter.convert(html).strip() == "⚠️"
+
+    def test_serverdc_emoticon_light_on(self, converter: Page.Converter) -> None:
+        html = (
+            '<img class="emoticon emoticon-light-on"'
+            ' data-emoticon-name="light-on"'
+            ' alt="(Glühbirne an)" />'
+        )
+        assert converter.convert(html).strip() == "💡"
+
+    def test_serverdc_emoticon_yes(self, converter: Page.Converter) -> None:
+        html = (
+            '<img class="emoticon emoticon-yes"'
+            ' data-emoticon-name="yes"'
+            ' alt="(Daumen hoch)" />'
+        )
+        assert converter.convert(html).strip() == "👍"
+
+    def test_serverdc_emoticon_fallback_to_alt_when_name_unknown(self, converter: Page.Converter) -> None:
+        html = (
+            '<img class="emoticon emoticon-unknown"'
+            ' data-emoticon-name="unknown_name"'
+            ' alt="(Unknown)" />'
+        )
+        # Falls back to alt text when data-emoticon-name is not recognized
+        assert converter.convert(html).strip() == "(Unknown)"


### PR DESCRIPTION
### Problem
On Confluence Server/Data Center, emoticons inserted via the classic "Insert Emoticon" dialog were not converted to Unicode, instead rendering as localized alt text (e.g., German "Warnung", "Haken", "Fehler").

### Root Cause
`Converter._convert_emoticon()` only recognized the Cloud attribute schema (`data-emoji-id`, `data-emoji-fallback`, etc.). Confluence Server/DC uses a different, older schema with `data-emoticon-name` instead.

### Solution
- Added `_EMOTICON_SERVERDC_NAMES` mapping (~30 classic emoticons)
- Extended `_convert_emoticon()` to check `data-emoticon-name` as fallback
- Maintains full backward compatibility with Cloud format
- Supports: tick, cross, yes, no, warning, forbidden, light-on/off, plus, minus, etc.

### Closes
Fixes #299
