### PR TITLE
fix(export): resolve raw img download URLs to local attachment paths

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2476,6 +2476,11 @@ class Page(Document):
 
             url_src = str(el.get("src", ""))
 
+            if not attachment and (url_src or el.get("href")):
+                attachment = self._attachment_from_download_href(
+                    url_src
+                ) or self._attachment_from_download_href(str(el.get("href", "")))
+
             if ".drawio.png" in url_src:
                 filename = unquote(urlparse(url_src).path.split("/")[-1])
                 drawio_result = self._convert_drawio_embedded_mermaid(filename)

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -675,6 +675,66 @@ class TestImageCaptionsInConvertImg:
         assert "My Caption" not in result
 
 
+class TestRawImgDownloadUrlResolution:
+    """Test resolution of raw <img src="/download/attachments/..."> tags (Issue #300)."""
+
+    def test_convert_img_with_relative_download_url(self) -> None:
+        att = _make_attachment("123", "guid-123", title="raw_image.png")
+        page = _make_page(
+            body='<img src="/download/attachments/999/raw_image.png?version=1" alt="My Raw Image">',
+            body_export="",
+            attachments=[att],
+        )
+        _att_path = "{space_name}/attachments/{attachment_file_id}{attachment_extension}"
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.attachment_href = "relative"
+            s.export.attachment_path = _att_path
+            s.export.page_href = "relative"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            s.export.image_captions = False
+            s.export.include_document_title = False
+            s.export.page_breadcrumbs = False
+            conv = Page.Converter(page)
+            result = conv.convert(page.body).strip()
+
+        assert "![My Raw Image](attachments/guid-123.png)" in result
+
+    def test_convert_img_with_absolute_download_url(self) -> None:
+        att = _make_attachment("123", "guid-123", title="raw_image.png")
+        url = "https://confluence.example.com/download/attachments/999/raw_image.png"
+        page = _make_page(
+            body=f'<img src="{url}" alt="Absolute">',
+            body_export="",
+            attachments=[att],
+        )
+        _att_path = "{space_name}/attachments/{attachment_file_id}{attachment_extension}"
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.attachment_href = "relative"
+            s.export.attachment_path = _att_path
+            s.export.page_href = "relative"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            s.export.image_captions = False
+            s.export.include_document_title = False
+            s.export.page_breadcrumbs = False
+            conv = Page.Converter(page)
+            result = conv.convert(page.body).strip()
+
+        assert "![Absolute](attachments/guid-123.png)" in result
+
+    def test_referenced_attachments_includes_raw_download_url_image(self) -> None:
+        att = _make_attachment("123", "guid-123", title="raw_image.png")
+        page = _make_page(
+            body='<p>Some text</p><img src="/download/attachments/999/raw_image.png">',
+            body_export="",
+            attachments=[att],
+        )
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.attachments_export = "referenced"
+            exported = page._attachments_for_export()
+
+        assert att in exported
+
+
 class TestPageFromUrl:
     """Test cases for Page.from_url."""
 


### PR DESCRIPTION
### Problem

Some pages contain `<img>` tags referencing an attachment via a plain, absolute or relative Confluence download URL (e.g., `/download/attachments/<pageId>/<filename>`) without macro attributes (`data-media-id`, `data-linked-resource-file-id`, etc.). These were exported with the raw remote URL unchanged instead of resolving to local attachment paths.

### Solution

Added a fallback in `Page.Converter.convert_img()` to call `self._attachment_from_download_href()` when no data attributes match. This extracts the filename from the download URL path and matches it against page attachments, resolving the local attachment path via `_get_path_for_href()`.

### Changes

- `confluence_markdown_exporter/confluence.py`: Extended `convert_img()` to attempt attachment resolution from `src` or `href` download URLs via `_attachment_from_download_href()`
- `tests/unit/test_confluence.py`: Added unit tests for relative download URLs, absolute download URLs, and verified inclusion in `attachments_export="referenced"`

Resolves #300
