### PR TITLE
fix(comments): strip markdown links and truncate excerpt headings at word boundaries

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1071,6 +1071,26 @@ class Page(Document):
 
     _COMMENT_TITLE_MAX_LEN = 60
 
+    @classmethod
+    def _truncate_excerpt(cls, text: str, max_len: int = _COMMENT_TITLE_MAX_LEN) -> str:
+        """Strip Markdown links/formatting and truncate text at word boundary."""
+        # Strip Markdown images ![alt](url) -> alt
+        clean = re.sub(r"!\[([^\]]*)\]\([^)]*\)", r"\1", text)
+        # Strip Markdown links [text](url) -> text
+        clean = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", clean)
+        # Strip Wiki links [[url|text]] -> text, [[text]] -> text
+        clean = re.sub(r"\[\[(?:[^|\]]*\|)?([^\]]+)\]\]", r"\1", clean)
+        # Collapse whitespace
+        clean = re.sub(r"\s+", " ", clean).strip()
+
+        if len(clean) <= max_len:
+            return clean
+
+        truncated = clean[:max_len]
+        if " " in truncated:
+            truncated = truncated.rsplit(" ", 1)[0]
+        return truncated.rstrip(".,:;!? ") + "…"
+
     def _fetch_inline_comments(self) -> list[dict]:
         client = get_thread_confluence(self.base_url)
         results: list[dict] = []
@@ -1187,9 +1207,7 @@ class Page(Document):
             ref = comment.get("extensions", {}).get("inlineProperties", {}).get("markerRef", "")
             marked_md = self._marked_texts.get(ref, "")
 
-            plain = re.sub(r"\s+", " ", marked_md).strip()
-            n = self._COMMENT_TITLE_MAX_LEN
-            short_title = plain[:n] + "…" if len(plain) > n else plain
+            short_title = self._truncate_excerpt(marked_md)
             if not short_title:
                 short_title = f"Comment {ref[:8]}"
             lines.append(f"### {short_title}")
@@ -1239,9 +1257,7 @@ class Page(Document):
                 .strip()
             )
 
-            plain = re.sub(r"\s+", " ", body_md).strip()
-            n = self._COMMENT_TITLE_MAX_LEN
-            short_title = plain[:n] + "…" if len(plain) > n else plain
+            short_title = self._truncate_excerpt(body_md)
             if not short_title:
                 short_title = f"Comment {str(comment.get('id', ''))[:8]}"
             lines.append(f"### {short_title}")

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1343,7 +1343,8 @@ def _make_comments_page(
     page.base_url = "https://example.atlassian.net"
     page.export_path = Path("TEAM/My Page.md")
     page._marked_texts = marked_texts or {}
-    page._COMMENT_TITLE_MAX_LEN = Page._COMMENT_TITLE_MAX_LEN.default
+    page._COMMENT_TITLE_MAX_LEN = Page._COMMENT_TITLE_MAX_LEN
+    page._truncate_excerpt = Page._truncate_excerpt
     page._fetch_inline_comments = lambda: list(inline_comments or [])
     page._fetch_page_comments = lambda: list(page_comments or [])
     replies_map = replies or {}
@@ -1509,6 +1510,36 @@ class TestPageCommentsSidecarBody:
 
         ids = [c["id"] for c in results]
         assert ids == ["open1", "open2"]
+
+
+class TestCommentExcerptTruncation:
+    """Test clean truncation of comment excerpt headings (Issue #301)."""
+
+    def test_truncate_excerpt_strips_markdown_links(self) -> None:
+        text = "siehe auch US [SSMPA-2656](https://jira.example.com/browse/SSMPA-2656) fuer Details"
+        result = Page._truncate_excerpt(text, max_len=60)
+        assert result == "siehe auch US SSMPA-2656 fuer Details"
+
+    def test_truncate_excerpt_strips_markdown_images(self) -> None:
+        text = "siehe Bild ![Screenshot](https://example.com/img.png) und Text"
+        result = Page._truncate_excerpt(text, max_len=60)
+        assert result == "siehe Bild Screenshot und Text"
+
+    def test_truncate_excerpt_strips_wiki_links(self) -> None:
+        text = "siehe [[Page Title|Display Text]] oder [[Simple Page]]"
+        result = Page._truncate_excerpt(text, max_len=60)
+        assert result == "siehe Display Text oder Simple Page"
+
+    def test_truncate_excerpt_word_boundary(self) -> None:
+        text = "Das ist ein sehr langer Kommentartext der definitiv gekuerzt werden muss"
+        result = Page._truncate_excerpt(text, max_len=30)
+        assert result == "Das ist ein sehr langer…"
+        assert not result.endswith(" l…")
+
+    def test_truncate_excerpt_no_truncation_when_short(self) -> None:
+        text = "Kurzer Kommentar"
+        result = Page._truncate_excerpt(text, max_len=60)
+        assert result == "Kurzer Kommentar"
 
 
 class TestPagePropertiesReportDataview:

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1300,6 +1300,7 @@ class TestInlineCommentsFrontMatter:
         ]
         page._fetch_page_comments = list
         page._fetch_comment_replies = lambda _cid: []
+        page._truncate_excerpt = Page._truncate_excerpt
         page._render_inline_comments = types.MethodType(Page._render_inline_comments, page)
         page._render_page_comments = types.MethodType(Page._render_page_comments, page)
 


### PR DESCRIPTION
### Problem

When exporting comments to `.comments.md` sidecar files, each comment receives an auto-generated `### <excerpt>` heading created by a hard character-count slice (`plain[:n] + "…"`). This does not respect word boundaries or Markdown syntax, which can lead to broken Markdown link/image markup in headings (e.g. `### siehe auch US [SSMPA-2656](https://jira.example.com/browse/SSMP…`).

### Solution

Implemented `Page._truncate_excerpt(text, max_len)` helper that:
- Strips Markdown links `[text](url)` -> `text`, images `![alt](url)` -> `alt`, and Wiki links `[[url|text]]` -> `text` before deriving the excerpt
- Truncates text at the nearest word boundary rather than a mid-word character cut
- Collapses extra whitespace and cleanly appends `…` when truncated

### Changes

- `confluence_markdown_exporter/confluence.py`: Added `Page._truncate_excerpt()` and updated `_render_inline_comments()` & `_render_page_comments()` to use it
- `tests/unit/test_confluence.py`: Added `TestCommentExcerptTruncation` with unit tests for link stripping, image stripping, wiki links, and word boundary truncation

Resolves #301
