### PR TITLE
fix(attachments): resolve .drawio extension independent of comment locale

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -740,7 +740,12 @@ class Attachment(Document):
 
     @property
     def extension(self) -> str:
-        if self.comment == "draw.io diagram" and self.media_type == "application/vnd.jgraph.mxfile":
+        # media_type is unique to draw.io diagram sources, so it alone is a
+        # reliable, locale-independent discriminator. `comment` is not: Confluence
+        # localizes it to the editing user's language (e.g. "diagramme draw.io" in
+        # French vs. "draw.io diagram" in English), so matching it exactly caused
+        # diagrams authored by non-English users to silently lose their extension.
+        if self.media_type == "application/vnd.jgraph.mxfile":
             return ".drawio"
         if self.comment == "draw.io preview" and self.media_type == "image/png":
             return ".drawio.png"

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -124,6 +124,7 @@ def _make_attachment(
     file_id: str,
     title: str = "file.png",
     media_type: str = "image/png",
+    comment: str = "",
 ) -> Attachment:
     space = Space(base_url="https://example.com", key="TS", name="Test", description="", homepage=0)
     version = Version(
@@ -145,7 +146,7 @@ def _make_attachment(
         file_id=file_id,
         collection_name="",
         download_link="/download",
-        comment="",
+        comment=comment,
     )
 
 
@@ -1878,6 +1879,43 @@ class TestPagePropertiesReportFrozenFetchesAllRows:
 
         assert "Page A" in result
         assert "Page B" not in result
+
+
+class TestAttachmentExtension:
+    """draw.io source attachments must resolve to `.drawio` regardless of language.
+
+    `comment` is localized by Confluence, but `media_type` is not.
+    """
+
+    DRAWIO_MEDIA_TYPE = "application/vnd.jgraph.mxfile"
+
+    def test_english_comment_resolves_to_drawio(self) -> None:
+        att = _make_attachment(
+            "1", "guid-1", media_type=self.DRAWIO_MEDIA_TYPE, comment="draw.io diagram"
+        )
+        assert att.extension == ".drawio"
+
+    def test_french_comment_resolves_to_drawio(self) -> None:
+        """The extension must not depend on `comment`'s language.
+
+        Confluence localizes `extensions.comment` (e.g. "diagramme draw.io" in French).
+        """
+        att = _make_attachment(
+            "2", "guid-2", media_type=self.DRAWIO_MEDIA_TYPE, comment="diagramme draw.io"
+        )
+        assert att.extension == ".drawio"
+
+    def test_missing_comment_resolves_to_drawio(self) -> None:
+        att = _make_attachment("3", "guid-3", media_type=self.DRAWIO_MEDIA_TYPE, comment="")
+        assert att.extension == ".drawio"
+
+    def test_drawio_preview_still_requires_comment_match(self) -> None:
+        att = _make_attachment("4", "guid-4", media_type="image/png", comment="draw.io preview")
+        assert att.extension == ".drawio.png"
+
+    def test_regular_png_without_drawio_comment_unaffected(self) -> None:
+        att = _make_attachment("5", "guid-5", media_type="image/png", comment="")
+        assert att.extension == ".png"
 
 
 class TestAttachmentTemplateVars:


### PR DESCRIPTION
## Summary

Fixes #309.

`Attachment.extension` only resolved draw.io diagram sources to `.drawio` when `extensions.comment` exactly matched the hardcoded English string `"draw.io diagram"`. Confluence localizes that field to the editing user's language (confirmed via the REST API: `"diagramme draw.io"` for a French-locale user, same `media_type`), so any diagram authored by a non-English user fell through to `mimetypes.guess_extension("application/vnd.jgraph.mxfile")`, which returns `None`, leaving the file with no extension at all.

`media_type == "application/vnd.jgraph.mxfile"` is unique to draw.io diagram sources and is not localized, so it's used as the sole discriminator for that case. The `.drawio.png` preview case is left untouched — its `comment` ("draw.io preview") was verified to stay in English even on a French-locale page in the same test sample, so there's no confirmed bug there, and `media_type` alone (`image/png`) isn't a safe discriminator since regular screenshots share it.

## Test plan

- [x] Added `TestAttachmentExtension` covering: English comment, French comment, missing comment (all → `.drawio`), preview still requires its comment match, and an unrelated plain PNG is unaffected.
- [x] `uv run pytest` — 512 passed
- [x] `uv run ruff check` — clean on changed files
