### PR TITLE
feat(config): add comment_headings option to toggle excerpt headings

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1207,11 +1207,12 @@ class Page(Document):
             ref = comment.get("extensions", {}).get("inlineProperties", {}).get("markerRef", "")
             marked_md = self._marked_texts.get(ref, "")
 
-            short_title = self._truncate_excerpt(marked_md)
-            if not short_title:
-                short_title = f"Comment {ref[:8]}"
-            lines.append(f"### {short_title}")
-            lines.append("")
+            if settings.export.comment_headings:
+                short_title = self._truncate_excerpt(marked_md)
+                if not short_title:
+                    short_title = f"Comment {ref[:8]}"
+                lines.append(f"### {short_title}")
+                lines.append("")
 
             if marked_md:
                 lines.extend(
@@ -1257,11 +1258,12 @@ class Page(Document):
                 .strip()
             )
 
-            short_title = self._truncate_excerpt(body_md)
-            if not short_title:
-                short_title = f"Comment {str(comment.get('id', ''))[:8]}"
-            lines.append(f"### {short_title}")
-            lines.append("")
+            if settings.export.comment_headings:
+                short_title = self._truncate_excerpt(body_md)
+                if not short_title:
+                    short_title = f"Comment {str(comment.get('id', ''))[:8]}"
+                lines.append(f"### {short_title}")
+                lines.append("")
 
             author = comment.get("history", {}).get("createdBy", {}).get("displayName", "Unknown")
             created = comment.get("history", {}).get("createdDate", "")[:10]

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -1071,6 +1071,26 @@ class Page(Document):
 
     _COMMENT_TITLE_MAX_LEN = 60
 
+    @classmethod
+    def _truncate_excerpt(cls, text: str, max_len: int = _COMMENT_TITLE_MAX_LEN) -> str:
+        """Strip Markdown links/formatting and truncate text at word boundary."""
+        # Strip Markdown images ![alt](url) -> alt
+        clean = re.sub(r"!\[([^\]]*)\]\([^)]*\)", r"\1", text)
+        # Strip Markdown links [text](url) -> text
+        clean = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", clean)
+        # Strip Wiki links [[url|text]] -> text, [[text]] -> text
+        clean = re.sub(r"\[\[(?:[^|\]]*\|)?([^\]]+)\]\]", r"\1", clean)
+        # Collapse whitespace
+        clean = re.sub(r"\s+", " ", clean).strip()
+
+        if len(clean) <= max_len:
+            return clean
+
+        truncated = clean[:max_len]
+        if " " in truncated:
+            truncated = truncated.rsplit(" ", 1)[0]
+        return truncated.rstrip(".,:;!? ") + "…"
+
     def _fetch_inline_comments(self) -> list[dict]:
         client = get_thread_confluence(self.base_url)
         results: list[dict] = []
@@ -1187,9 +1207,7 @@ class Page(Document):
             ref = comment.get("extensions", {}).get("inlineProperties", {}).get("markerRef", "")
             marked_md = self._marked_texts.get(ref, "")
 
-            plain = re.sub(r"\s+", " ", marked_md).strip()
-            n = self._COMMENT_TITLE_MAX_LEN
-            short_title = plain[:n] + "…" if len(plain) > n else plain
+            short_title = self._truncate_excerpt(marked_md)
             if not short_title:
                 short_title = f"Comment {ref[:8]}"
             lines.append(f"### {short_title}")
@@ -1239,9 +1257,7 @@ class Page(Document):
                 .strip()
             )
 
-            plain = re.sub(r"\s+", " ", body_md).strip()
-            n = self._COMMENT_TITLE_MAX_LEN
-            short_title = plain[:n] + "…" if len(plain) > n else plain
+            short_title = self._truncate_excerpt(body_md)
             if not short_title:
                 short_title = f"Comment {str(comment.get('id', ''))[:8]}"
             lines.append(f"### {short_title}")

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -633,6 +633,15 @@ class ExportConfig(BaseModel):
             "API calls per page when enabled."
         ),
     )
+    comment_headings: bool = Field(
+        default=True,
+        title="Include Comment Excerpt Headings",
+        description=(
+            "Whether to include auto-generated '### <excerpt>' headings for each comment "
+            "in exported '.comments.md' sidecar files. "
+            "When set to false, comments are listed without individual '###' excerpt headings."
+        ),
+    )
     convert_status_badges: bool = Field(
         default=True,
         title="Convert Status Badges",

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1343,7 +1343,8 @@ def _make_comments_page(
     page.base_url = "https://example.atlassian.net"
     page.export_path = Path("TEAM/My Page.md")
     page._marked_texts = marked_texts or {}
-    page._COMMENT_TITLE_MAX_LEN = Page._COMMENT_TITLE_MAX_LEN.default
+    page._COMMENT_TITLE_MAX_LEN = Page._COMMENT_TITLE_MAX_LEN
+    page._truncate_excerpt = Page._truncate_excerpt
     page._fetch_inline_comments = lambda: list(inline_comments or [])
     page._fetch_page_comments = lambda: list(page_comments or [])
     replies_map = replies or {}
@@ -1509,6 +1510,36 @@ class TestPageCommentsSidecarBody:
 
         ids = [c["id"] for c in results]
         assert ids == ["open1", "open2"]
+
+
+class TestCommentExcerptTruncation:
+    """Test clean truncation of comment excerpt headings (Issue #301)."""
+
+    def test_truncate_excerpt_strips_markdown_links(self) -> None:
+        text = "siehe auch US [SSMPA-2656](https://jira.example.com/browse/SSMPA-2656) fuer Details"
+        result = Page._truncate_excerpt(text, max_len=60)
+        assert result == "siehe auch US SSMPA-2656 fuer Details"
+
+    def test_truncate_excerpt_strips_markdown_images(self) -> None:
+        text = "siehe Bild ![Screenshot](https://example.com/img.png) und Text"
+        result = Page._truncate_excerpt(text, max_len=60)
+        assert result == "siehe Bild Screenshot und Text"
+
+    def test_truncate_excerpt_strips_wiki_links(self) -> None:
+        text = "siehe [[Page Title|Display Text]] oder [[Simple Page]]"
+        result = Page._truncate_excerpt(text, max_len=60)
+        assert result == "siehe Display Text oder Simple Page"
+
+    def test_truncate_excerpt_word_boundary(self) -> None:
+        text = "Das ist ein sehr langer Kommentartext der definitiv gekuerzt werden muss"
+        result = Page._truncate_excerpt(text, max_len=30)
+        assert result == "Das ist ein sehr langer…"
+        assert not result.endswith(" l…")
+
+    def test_truncate_excerpt_no_truncation_when_short(self) -> None:
+        text = "Kurzer Kommentar"
+        result = Page._truncate_excerpt(text, max_len=60)
+        assert result == "Kurzer Kommentar"
 
 
 class TestPagePropertiesReportDataview:

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1300,6 +1300,7 @@ class TestInlineCommentsFrontMatter:
         ]
         page._fetch_page_comments = list
         page._fetch_comment_replies = lambda _cid: []
+        page._truncate_excerpt = Page._truncate_excerpt
         page._render_inline_comments = types.MethodType(Page._render_inline_comments, page)
         page._render_page_comments = types.MethodType(Page._render_page_comments, page)
 

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1310,6 +1310,7 @@ class TestInlineCommentsFrontMatter:
         ):
             s.export.output_path = Path("out")
             s.export.comments_export = "inline"
+            s.export.comment_headings = True
             Page.export_comments_sidecar(page)
 
         assert mock_save.called
@@ -1327,6 +1328,69 @@ class TestInlineCommentsFrontMatter:
         assert "\npage_id:" not in content
         assert "\npage_title:" not in content
         assert "\nsource:" not in content
+
+
+class TestCommentHeadingsConfig:
+    """Test comment_headings setting toggling excerpt headings."""
+
+    def test_comment_headings_disabled(self) -> None:
+        page = MockPage()
+        page.id = 123
+        page.title = "My Page"
+        page.space = MagicMock()
+        page.space.key = "TEAM"
+        page.base_url = "https://example.atlassian.net"
+        page.export_path = Path("TEAM/My Page.md")
+        page._marked_texts = {"ref-1": "marked excerpt"}
+        page._COMMENT_TITLE_MAX_LEN = Page._COMMENT_TITLE_MAX_LEN.default
+        page._fetch_inline_comments = lambda: [
+            {
+                "id": "c1",
+                "extensions": {"inlineProperties": {"markerRef": "ref-1"}},
+                "history": {
+                    "createdBy": {"displayName": "Alice"},
+                    "createdDate": "2026-04-01T10:00:00Z",
+                },
+                "body": {"view": {"value": "<p>nice</p>"}},
+            }
+        ]
+        page._fetch_page_comments = lambda: [
+            {
+                "id": "c2",
+                "history": {
+                    "createdBy": {"displayName": "Bob"},
+                    "createdDate": "2026-04-02T10:00:00Z",
+                },
+                "body": {"view": {"value": "<p>footer comment</p>"}},
+            }
+        ]
+        page._fetch_comment_replies = lambda _cid: []
+        page._truncate_excerpt = Page._truncate_excerpt
+        page._render_inline_comments = types.MethodType(Page._render_inline_comments, page)
+        page._render_page_comments = types.MethodType(Page._render_page_comments, page)
+
+        with (
+            patch("confluence_markdown_exporter.confluence.save_file") as mock_save,
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
+            s.export.output_path = Path("out")
+            s.export.comments_export = "all"
+            s.export.comment_headings = False
+            Page.export_comments_sidecar(page)
+
+        assert mock_save.called
+        content = mock_save.call_args[0][1]
+
+        # Section headings remain
+        assert "## Inline comments" in content
+        assert "## Page comments" in content
+        # Excerpt '### ' headings must not be present
+        assert "### " not in content
+        # Authors and bodies are present
+        assert "**Alice** · 2026-04-01" in content
+        assert "nice" in content
+        assert "**Bob** · 2026-04-02" in content
+        assert "footer comment" in content
 
 
 def _make_comments_page(


### PR DESCRIPTION
## Problem

When exporting comments to .comments.md sidecar files, each comment gets an auto-generated ### <excerpt> heading based on the comment/marked text. In Confluence itself, comments do not have titles or headings, and having artificial ### headings can clutter Markdown files when viewing comments.

## Solution

Added a new boolean setting comment_headings (default True for backwards compatibility).
When set to alse (or via CME_EXPORT__COMMENT_HEADINGS=false), the auto-generated ### <excerpt> headings are omitted, rendering only section headers (## Inline comments / ## Page comments) and individual comment author/date blocks and bodies.
## Dependencies

- Depends on #308 - this branch builds directly on the comment-excerpt-heading cleanup from #308.