### PR TITLE
feat(attachments): generic extension resolution system with vendor rules

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -740,7 +740,12 @@ class Attachment(Document):
 
     @property
     def extension(self) -> str:
-        if self.comment == "draw.io diagram" and self.media_type == "application/vnd.jgraph.mxfile":
+        # media_type is unique to draw.io diagram sources, so it alone is a
+        # reliable, locale-independent discriminator. `comment` is not: Confluence
+        # localizes it to the editing user's language (e.g. "diagramme draw.io" in
+        # French vs. "draw.io diagram" in English), so matching it exactly caused
+        # diagrams authored by non-English users to silently lose their extension.
+        if self.media_type == "application/vnd.jgraph.mxfile":
             return ".drawio"
         if self.comment == "draw.io preview" and self.media_type == "image/png":
             return ".drawio.png"

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -772,20 +772,6 @@ def _gliffy_extension_fallback(att: "Attachment") -> bool:
     return False
 
 
-REGISTERED_EXTENSION_RULES: list[ExtensionRule] = [
-    ExtensionRule(
-        extension=".drawio",
-        media_types=("application/vnd.jgraph.mxfile",),
-        fallback=_drawio_extension_fallback,
-    ),
-    ExtensionRule(
-        extension=".gliffy",
-        media_types=("application/gliffy+json",),
-        fallback=_gliffy_extension_fallback,
-    ),
-]
-
-
 class Attachment(Document):
     id: str
     file_size: int
@@ -928,6 +914,24 @@ class Attachment(Document):
         save_file(filepath, response.content)
         logger.debug("Saved attachment '%s' (%d bytes)", self.title, len(response.content))
         stats.inc_attachments_exported()
+
+
+# Defined after Attachment (not before, like ExtensionRule/Attachment.extension itself) - the
+# forward-referenced "Attachment" type hint on ExtensionRule.fallback is only evaluated by
+# pydantic once an ExtensionRule instance is actually constructed, and under Python 3.13 that
+# evaluation happens eagerly, failing if Attachment does not exist yet in the module namespace.
+REGISTERED_EXTENSION_RULES: list[ExtensionRule] = [
+    ExtensionRule(
+        extension=".drawio",
+        media_types=("application/vnd.jgraph.mxfile",),
+        fallback=_drawio_extension_fallback,
+    ),
+    ExtensionRule(
+        extension=".gliffy",
+        media_types=("application/gliffy+json",),
+        fallback=_gliffy_extension_fallback,
+    ),
+]
 
 
 class Ancestor(Document):

--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -14,6 +14,7 @@ import os
 import re
 import urllib.parse
 import zlib
+from collections.abc import Callable
 from collections.abc import Set
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import as_completed
@@ -37,6 +38,7 @@ from markdownify import ATX
 from markdownify import MarkdownConverter
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic.dataclasses import dataclass
 from requests import HTTPError
 from requests import RequestException
 from rich.progress import BarColumn
@@ -728,6 +730,62 @@ class Document(BaseModel):
         }
 
 
+@dataclass
+class ExtensionRule:
+    """Rule for resolving file extensions for vendor-specific attachments."""
+
+    extension: str
+    media_types: tuple[str, ...]
+    fallback: Callable[["Attachment"], str | bool | None] | None = None
+
+    def resolve(self, att: "Attachment") -> str | None:
+        """Attempt to resolve the file extension for *att*.
+
+        Checks primary media types first; if they do not match, executes the
+        rule's fallback function (if any) before returning None.
+        """
+        if att.media_type in self.media_types:
+            return self.extension
+
+        if self.fallback:
+            result = self.fallback(att)
+            if isinstance(result, str):
+                return result
+            if result is True:
+                return self.extension
+
+        return None
+
+
+def _drawio_extension_fallback(att: "Attachment") -> str | bool | None:
+    """Fallback for draw.io attachments (e.g. preview images)."""
+    if att.media_type == "image/png" and att.comment and "draw.io preview" in att.comment.lower():
+        return ".drawio.png"
+    return None
+
+
+def _gliffy_extension_fallback(att: "Attachment") -> bool:
+    """Fallback for Gliffy diagrams (e.g. when media_type is generic JSON/XML)."""
+    if att.media_type in ("application/json", "application/xml", "text/xml"):
+        text = f"{att.comment or ''} {att.title or ''}".lower()
+        return "gliffy" in text or att.title.lower().endswith(".gliffy")
+    return False
+
+
+REGISTERED_EXTENSION_RULES: list[ExtensionRule] = [
+    ExtensionRule(
+        extension=".drawio",
+        media_types=("application/vnd.jgraph.mxfile",),
+        fallback=_drawio_extension_fallback,
+    ),
+    ExtensionRule(
+        extension=".gliffy",
+        media_types=("application/gliffy+json",),
+        fallback=_gliffy_extension_fallback,
+    ),
+]
+
+
 class Attachment(Document):
     id: str
     file_size: int
@@ -740,17 +798,24 @@ class Attachment(Document):
 
     @property
     def extension(self) -> str:
-        # media_type is unique to draw.io diagram sources, so it alone is a
-        # reliable, locale-independent discriminator. `comment` is not: Confluence
-        # localizes it to the editing user's language (e.g. "diagramme draw.io" in
-        # French vs. "draw.io diagram" in English), so matching it exactly caused
-        # diagrams authored by non-English users to silently lose their extension.
-        if self.media_type == "application/vnd.jgraph.mxfile":
-            return ".drawio"
-        if self.comment == "draw.io preview" and self.media_type == "image/png":
-            return ".drawio.png"
+        # 1. Registered vendor-specific rules (media type match -> fallback)
+        for rule in REGISTERED_EXTENSION_RULES:
+            if ext := rule.resolve(self):
+                return ext
 
-        return mimetypes.guess_extension(self.media_type) or ""
+        # 2. Standard Python mimetypes module
+        guessed = mimetypes.guess_extension(self.media_type)
+        if guessed and guessed != ".bin":
+            return guessed
+
+        # 3. Final fallback: extract extension from attachment title if present
+        if self.title and "." in self.title:
+            ext = Path(self.title).suffix
+            max_ext_len = 10
+            if ext and len(ext) <= max_ext_len:
+                return ext
+
+        return guessed or ""
 
     @property
     def filename(self) -> str:

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -124,6 +124,7 @@ def _make_attachment(
     file_id: str,
     title: str = "file.png",
     media_type: str = "image/png",
+    comment: str = "",
 ) -> Attachment:
     space = Space(base_url="https://example.com", key="TS", name="Test", description="", homepage=0)
     version = Version(
@@ -145,7 +146,7 @@ def _make_attachment(
         file_id=file_id,
         collection_name="",
         download_link="/download",
-        comment="",
+        comment=comment,
     )
 
 
@@ -1878,6 +1879,43 @@ class TestPagePropertiesReportFrozenFetchesAllRows:
 
         assert "Page A" in result
         assert "Page B" not in result
+
+
+class TestAttachmentExtension:
+    """draw.io source attachments must resolve to `.drawio` regardless of language.
+
+    `comment` is localized by Confluence, but `media_type` is not.
+    """
+
+    DRAWIO_MEDIA_TYPE = "application/vnd.jgraph.mxfile"
+
+    def test_english_comment_resolves_to_drawio(self) -> None:
+        att = _make_attachment(
+            "1", "guid-1", media_type=self.DRAWIO_MEDIA_TYPE, comment="draw.io diagram"
+        )
+        assert att.extension == ".drawio"
+
+    def test_french_comment_resolves_to_drawio(self) -> None:
+        """The extension must not depend on `comment`'s language.
+
+        Confluence localizes `extensions.comment` (e.g. "diagramme draw.io" in French).
+        """
+        att = _make_attachment(
+            "2", "guid-2", media_type=self.DRAWIO_MEDIA_TYPE, comment="diagramme draw.io"
+        )
+        assert att.extension == ".drawio"
+
+    def test_missing_comment_resolves_to_drawio(self) -> None:
+        att = _make_attachment("3", "guid-3", media_type=self.DRAWIO_MEDIA_TYPE, comment="")
+        assert att.extension == ".drawio"
+
+    def test_drawio_preview_still_requires_comment_match(self) -> None:
+        att = _make_attachment("4", "guid-4", media_type="image/png", comment="draw.io preview")
+        assert att.extension == ".drawio.png"
+
+    def test_regular_png_without_drawio_comment_unaffected(self) -> None:
+        att = _make_attachment("5", "guid-5", media_type="image/png", comment="")
+        assert att.extension == ".png"
 
 
 class TestAttachmentTemplateVars:

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -1882,12 +1882,13 @@ class TestPagePropertiesReportFrozenFetchesAllRows:
 
 
 class TestAttachmentExtension:
-    """draw.io source attachments must resolve to `.drawio` regardless of language.
+    """Vendor source attachments (draw.io, gliffy) must resolve to their correct extensions.
 
     `comment` is localized by Confluence, but `media_type` is not.
     """
 
     DRAWIO_MEDIA_TYPE = "application/vnd.jgraph.mxfile"
+    GLIFFY_MEDIA_TYPE = "application/gliffy+json"
 
     def test_english_comment_resolves_to_drawio(self) -> None:
         att = _make_attachment(
@@ -1913,8 +1914,28 @@ class TestAttachmentExtension:
         att = _make_attachment("4", "guid-4", media_type="image/png", comment="draw.io preview")
         assert att.extension == ".drawio.png"
 
+    def test_gliffy_media_type_resolves_to_gliffy(self) -> None:
+        att = _make_attachment("5", "guid-5", media_type=self.GLIFFY_MEDIA_TYPE, comment="")
+        assert att.extension == ".gliffy"
+
+    def test_gliffy_json_fallback_resolves_to_gliffy(self) -> None:
+        att = _make_attachment(
+            "6", "guid-6", title="diagram.gliffy", media_type="application/json", comment=""
+        )
+        assert att.extension == ".gliffy"
+
+    def test_title_suffix_fallback(self) -> None:
+        att = _make_attachment(
+            "7",
+            "guid-7",
+            title="custom-file.xyz",
+            media_type="application/octet-stream",
+            comment="",
+        )
+        assert att.extension == ".xyz"
+
     def test_regular_png_without_drawio_comment_unaffected(self) -> None:
-        att = _make_attachment("5", "guid-5", media_type="image/png", comment="")
+        att = _make_attachment("8", "guid-8", media_type="image/png", comment="")
         assert att.extension == ".png"
 
 


### PR DESCRIPTION
### Problem

Attachment extension resolution relied on inline `if` conditions checking hardcoded English strings (e.g. `self.comment == 'draw.io diagram'`), which failed on non-English Confluence instances (#309). Furthermore, other vendor source files such as Gliffy diagrams (`application/gliffy+json`) or files with unknown MIME types were assigned no file extension at all.

### Solution

Introduced a modular, generic extension resolution system in `Attachment.extension` as proposed in #313:

1. **`ExtensionRule` dataclass:** Binds primary MIME types, target file extensions, and optional per-vendor fallback functions into isolated, declarative rule objects.
2. **Modular Registry:** Registered rules for Draw.io (`.drawio`, `.drawio.png`) and Gliffy (`.gliffy`, with fallback for generic JSON/XML).
3. **Multi-tier Resolution Chain:**
   - Vendor rules & fallbacks
   - Standard Python `mimetypes`
   - Title extension fallback (`Path(self.title).suffix`) for unknown MIME types (`application/octet-stream`).

### Changes

- `confluence_markdown_exporter/confluence.py`: Defined `ExtensionRule`, vendor fallback handlers, and updated `Attachment.extension`.
- `tests/unit/test_confluence.py`: Added unit tests for Draw.io, Gliffy, and title suffix fallbacks.

### Dependencies

- Depends on #310 - this branch builds on and generalizes the Draw.io locale fix from #310 (merged in as the actual, unmodified commit rather than re-implemented, so it stays reconcilable once #310 lands). Please merge #310 first, or merge this PR with that understanding.

Resolves #309
Resolves #313
