### PR TITLE
fix(export): resolve relative Server/DC page links without page_id (/display/SPACE/TITLE)

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2303,8 +2303,27 @@ class Page(Document):
                     if page_id_param and page_id_param.isdigit():
                         return self.convert_page_link(int(page_id_param))
                     if match := parse_confluence_path(parsed_href.path):
-                        if match.page_id:
-                            return self.convert_page_link(match.page_id)
+                        page_id = match.page_id
+                        if not page_id and match.space_key and match.page_title:
+                            try:
+                                page_data = _require_dict(
+                                    get_thread_confluence(self.page.base_url).get_page_by_title(
+                                        space=match.space_key,
+                                        title=match.page_title,
+                                        expand="version",
+                                    ),
+                                    f"page title={match.page_title!r} space={match.space_key!r}",
+                                )
+                                if page_data.get("id"):
+                                    page_id = int(page_data["id"])
+                            except Exception as e:  # noqa: BLE001
+                                logger.debug(
+                                    f"Could not resolve page by space '{match.space_key}' "
+                                    f"and title '{match.page_title}': {e}"
+                                )
+
+                        if page_id:
+                            return self.convert_page_link(page_id)
             if (href := href_str).startswith("#"):
                 if settings.export.page_href == "wiki":
                     return f"[[#{text}]]"

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -2123,6 +2123,39 @@ class TestAbsoluteUrlPageLinks:
         PageTitleRegistry.reset()
         assert result == "[[Legacy Page]]"
 
+    def test_relative_server_display_url_resolves_page_by_title(self) -> None:
+        from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
+
+        PageTitleRegistry.reset()
+        target = self._make_target_page(777, "SFDC Integration", "AOSAPXI")
+        source = _make_page(body="", body_export="", attachments=[])
+
+        mock_client = MagicMock()
+        mock_client.get_page_by_title.return_value = {"id": 777}
+
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.get_thread_confluence",
+                return_value=mock_client,
+            ),
+            patch(
+                "confluence_markdown_exporter.confluence.Page.from_id",
+                return_value=target,
+            ),
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
+            s.export.page_href = "wiki"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            conv = Page.Converter(source)
+            html = '<a href="/display/AOSAPXI/SFDC_Integration">SFDC_Integration</a>'
+            result = conv.convert(html).strip()
+
+        PageTitleRegistry.reset()
+        mock_client.get_page_by_title.assert_called_once_with(
+            space="AOSAPXI", title="SFDC_Integration", expand="version"
+        )
+        assert result == "[[SFDC Integration]]"
+
 
 class TestColumnLayoutConversion:
     """Confluence multi-column layouts must not be stripped from the output.


### PR DESCRIPTION
### Problem

On Confluence Server / Data Center, relative page links between different spaces render in `body.view` HTML as `/display/SPACEKEY/Page+Title` without `data-linked-resource-id` or explicit `pageId` query parameters.

Currently, `convert_a()` in `confluence.py` parses relative paths using `parse_confluence_path(parsed_href.path)`. For Server/DC URLs, `parse_confluence_path` extracts `space_key` and `page_title`, leaving `page_id=None`. Because `convert_a()` only converted page links when `match.page_id` was non-null, it skipped these matches and fell back to `super().convert_a()`, outputting raw relative Markdown links like `[SFDC_Integration](/display/AOSAPXI/SFDC_Integration)`.

### Solution

When `match.page_id` is missing but `match.space_key` and `match.page_title` are present, `convert_a()` now queries the Confluence REST API (`get_page_by_title`) to resolve the target `page_id` dynamically, then passes it to `convert_page_link()`.

### Changes

* `confluence_markdown_exporter/confluence.py`: Updated `convert_a()` to resolve missing `page_id` by space key and title via REST API before delegating to `convert_page_link()`.
* `tests/unit/test_confluence.py`: Added unit test `test_relative_server_display_url_resolves_page_by_title` verifying title-based resolution for `/display/SPACE/TITLE` links.

### Testing

* Verified via new unit test mocking `get_page_by_title` and `Page.from_id`.
* Tested against real Confluence Server export (Page ID `120184664`).
* Pre-commit gates (`uv run ruff check`) passed with 0 errors.

Resolves #314
