### PR TITLE
fix(export): sanitize link destinations with parentheses and clean up URL anchor text

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2310,7 +2310,26 @@ class Page(Document):
                     return f"[[#{text}]]"
                 return f"[{text}](#{github_heading_slug(href[1:])})"
 
-            return super().convert_a(el, text, parent_tags)
+            res = super().convert_a(el, text, parent_tags)
+            if res.startswith("[") and "](" in res and res.endswith(")"):
+                idx = res.find("](")
+                link_text = res[1:idx]
+                link_url = res[idx + 2 : -1]
+
+                # Sanitize link destination: encode parentheses that break Markdown link syntax
+                sanitized_url = urllib.parse.quote(link_url, safe=":/%?&=#+@$,;-~_.*'![]")
+
+                # If link text is an unformatted URL, clean up backslash-escaped underscores
+                if (
+                    link_text.startswith(("http://", "https://"))
+                    or unquote(link_text).replace("\\_", "_") == unquote(link_url)
+                ):
+                    link_text = link_text.replace("\\_", "_")
+
+                return f"[{link_text}]({sanitized_url})"
+
+
+            return res
 
         def convert_page_link(self, page_id: int) -> str:
             if not page_id:

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -603,6 +603,41 @@ class TestParseImageCaptions:
         result = _parse_image_captions(storage)
         assert result == {"a.png": "Caption A", "c.jpg": "Caption C"}
 
+
+class TestLinkSanitization:
+    """Tests for link sanitization and URL anchor text cleanup."""
+
+    def test_kibana_url_parentheses_sanitized(self) -> None:
+        page = MockPage()
+        page.html = (
+            '<a href="https://kibana.example.com/app/kibana#/dashboard/AWW0?_g=()&amp;'
+            '_a=(desc:%27test%27)">Kibana Dashboard</a>'
+        )
+        conv = Page.Converter(page)
+        expected = (
+            "[Kibana Dashboard]"
+            "(https://kibana.example.com/app/kibana#/dashboard/AWW0?_g=%28%29&_a=%28desc:%27test%27%29)"
+        )
+        assert expected in conv.markdown
+
+    def test_url_anchor_text_underscores_not_escaped(self) -> None:
+        page = MockPage()
+        page.html = (
+            '<a href="https://kibana.example.com/app/kibana#/dashboard/AWW0_8x?param=1">'
+            "https://kibana.example.com/app/kibana#/dashboard/AWW0_8x</a>"
+        )
+        conv = Page.Converter(page)
+        expected = (
+            "[https://kibana.example.com/app/kibana#/dashboard/AWW0_8x]"
+            "(https://kibana.example.com/app/kibana#/dashboard/AWW0_8x?param=1)"
+        )
+        assert expected in conv.markdown
+
+
+
+
+
+
     def test_empty_storage_returns_empty(self) -> None:
         from confluence_markdown_exporter.confluence import _parse_image_captions
 


### PR DESCRIPTION
### Problem
When Confluence pages contain links with special characters in the URL query string—such as unescaped parentheses `()` in Kibana or Grafana URLs (e.g. `?_g=()&_a=(description:...)`)—Markdown link syntax `[text](url)` breaks because the closing parenthesis `)` terminates the link destination prematurely. The remainder of the URL query string is left behind as raw unformatted text, which frequently breaks table cell layouts and document structure.

Furthermore, when link anchor text is an unformatted URL (or matches the target URL), `markdownify` escapes underscores in the anchor text as `\_` (e.g. `[http://foo\_bar](...)`), rendering literal backslashes inside link labels or breaking exact match expectations.

### Solution / Changes
- Updated `convert_a` in `confluence_markdown_exporter/confluence.py`:
  - Enforces URL sanitization on link destinations via `urllib.parse.quote`, encoding unescaped parentheses `()` as `%28` / `%29`.
  - Cleans up escaped underscores in the link anchor text if the text represents an unformatted URL.
- Added unit tests in `tests/unit/test_confluence.py` (`TestLinkSanitization`).

### Issues
- Resolves #316
