### PR TITLE
fix(macro): render viewpdf (PDF/file preview) macro as attachment link

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -26,6 +26,7 @@ from typing import Literal
 from typing import TypeAlias
 from typing import cast
 from urllib.parse import unquote
+from urllib.parse import unquote_plus
 from urllib.parse import urlparse
 
 import yaml
@@ -1784,6 +1785,7 @@ class Page(Document):
                     "toc": self.convert_toc,
                     "jira": self.convert_jira_table,
                     "attachments": self.convert_attachments,
+                    "viewpdf": self.convert_viewpdf,
                     "markdown": self.convert_markdown,
                     "mohamicorp-markdown": self.convert_markdown,
                     "include": self.convert_include,
@@ -2378,6 +2380,25 @@ class Page(Document):
                 return f"[{text}]({href})"
 
             return self._format_attachment_link(attachment)
+
+        def convert_viewpdf(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
+            """Convert the PDF/file preview macro (`viewpdf`) to a Markdown attachment link.
+
+            The macro renders as a clientside preview widget with no static link in
+            body.view/body.export_view, but the wrapping element carries the referenced
+            attachment as `data-attachment-id`/`data-attachment` (URL-encoded filename).
+            """
+            attachment = None
+            if aid := el.get("data-attachment-id"):
+                attachment = self.page.get_attachment_by_id(str(aid))
+            if not attachment and (raw_filename := el.get("data-attachment")):
+                matches = self.page.get_attachments_by_title(unquote_plus(str(raw_filename)))
+                attachment = matches[0] if matches else None
+
+            if attachment is None:
+                return "\n<!-- viewpdf macro: attachment not found -->\n\n"
+
+            return f"\n{self._format_attachment_link(attachment)}\n\n"
 
         def convert_time(self, el: BeautifulSoup, text: str, parent_tags: list[str]) -> str:
             if el.has_attr("datetime"):

--- a/tests/unit/test_viewpdf_macro.py
+++ b/tests/unit/test_viewpdf_macro.py
@@ -1,0 +1,83 @@
+"""Unit tests for the `viewpdf` (PDF/file preview) macro conversion."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from confluence_markdown_exporter.confluence import Page
+
+
+class MockAttachment:
+    def __init__(self, title: str) -> None:
+        self.title = title
+        self.export_path = Path(f"TEST/attachments/{title}")
+
+
+class MockPage:
+    def __init__(self, attachments: list[MockAttachment]) -> None:
+        self.id = "test-page"
+        self.title = "Test Page"
+        self.html = ""
+        self.body_storage = ""
+        self.labels: list = []
+        self.ancestors: list = []
+        self.export_path = Path("TEST/Test Page.md")
+        self._attachments = attachments
+
+    def get_attachment_by_id(self, attachment_id: str) -> MockAttachment | None:
+        for a in self._attachments:
+            if getattr(a, "id", None) == attachment_id:
+                return a
+        return None
+
+    def get_attachment_by_file_id(self, _file_id: str) -> None:
+        return None
+
+    def get_attachments_by_title(self, title: str) -> list[MockAttachment]:
+        return [a for a in self._attachments if a.title == title]
+
+
+def _viewpdf_div(*, attachment_id: str = "", attachment: str = "") -> str:
+    return (
+        '<div class="vf-slide-viewer-macro conf-macro output-block" '
+        f'data-attachment="{attachment}" data-attachment-id="{attachment_id}" '
+        'data-macro-name="viewpdf">'
+        '<div class="vf-slide-viewer"></div>'
+        "</div>"
+    )
+
+
+class TestConvertViewpdf:
+    def test_resolves_attachment_by_id(self) -> None:
+        attachment = MockAttachment("Some Document.pdf")
+        attachment.id = "att132887794"
+        page = MockPage([attachment])
+        html = _viewpdf_div(attachment_id="att132887794", attachment="Some+Document.pdf")
+
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.attachment_href = "relative"
+            result = Page.Converter(page).convert(html).strip()  # type: ignore[arg-type]
+
+        assert "Some Document.pdf" in result
+
+    def test_falls_back_to_url_encoded_filename(self) -> None:
+        attachment = MockAttachment("Some Document.pdf")
+        page = MockPage([attachment])
+        # No attachment matches the (unknown) id, so the handler must fall back
+        # to the `data-attachment` filename, which is URL-encoded with `+` for spaces.
+        html = _viewpdf_div(attachment_id="att-unknown", attachment="Some+Document.pdf")
+
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.attachment_href = "relative"
+            result = Page.Converter(page).convert(html).strip()  # type: ignore[arg-type]
+
+        assert "Some Document.pdf" in result
+
+    def test_missing_attachment_returns_comment(self) -> None:
+        page = MockPage([])
+        html = _viewpdf_div(attachment_id="att-unknown", attachment="Missing.pdf")
+
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.attachment_href = "relative"
+            result = Page.Converter(page).convert(html).strip()  # type: ignore[arg-type]
+
+        assert "not found" in result


### PR DESCRIPTION
### Problem
Confluence's "View File"/PDF preview macro (`ac:name="viewpdf"`) is silently dropped during export - the resulting Markdown contains no link and no mention of the referenced attachment at all, even though the attachment itself is exported normally.

### Root Cause
`viewpdf` is not present in the `macro_handlers` dict in `Page.Converter.convert_div()`, so it falls through to the generic `super().convert_div(...)` fallback. The macro renders as a clientside preview widget with no static link in `body.view`/`body.export_view`, so nothing is converted - the section under the macro's heading ends up empty.

### Solution / Changes
- Added `convert_viewpdf()` to `Page.Converter`, registered under `"viewpdf"` in `macro_handlers`.
- Resolves the referenced attachment directly from the wrapping element's `data-attachment-id`/`data-attachment` (URL-encoded filename) attributes, already present in `body.view`/`body.export_view` - no need to cross-reference `body.storage`.
- Reuses the existing `_format_attachment_link()` helper for consistent Markdown link rendering (`wiki`/relative/absolute `attachment_href` modes).
- Falls back to an HTML comment (`<!-- viewpdf macro: attachment not found -->`) if the attachment can't be resolved, matching the existing pattern used by other macro handlers (e.g. `convert_drawio`, `convert_gliffy`).
- New tests in `tests/unit/test_viewpdf_macro.py`: resolution by `data-attachment-id`, fallback to `data-attachment` filename, and the missing-attachment case.
- Backward compatible: purely additive, no existing behavior changed.

### Issues
- `Resolves #318`
