### PR TITLE
fix(export): delete old file when a page is renamed or moved

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -3438,16 +3438,18 @@ def sync_removed_pages(base_url: str) -> None:
         logger.debug("Stale page cleanup disabled — skipping.")
         return
 
+    # Renamed and moved pages are seen during the run, so they never show up as
+    # unseen. Their old files still need removing, which needs no API call.
+    deleted: set[str] = set()
     unseen = LockfileManager.unseen_ids()
-    if not unseen:
-        logger.debug("No unseen pages in lockfile — nothing to clean up.")
-        return
+    if unseen:
+        with console.status(f"[dim]Checking {len(unseen)} unseen page(s) for removal…[/dim]"):
+            deleted = fetch_deleted_page_ids(sorted(unseen), base_url)
+        if deleted:
+            logger.info("Removing %d stale page(s) from local export.", len(deleted))
+    else:
+        logger.debug("No unseen pages in lockfile — skipping existence check.")
 
-    with console.status(f"[dim]Checking {len(unseen)} unseen page(s) for removal…[/dim]"):
-        deleted = fetch_deleted_page_ids(sorted(unseen), base_url)
-
-    if deleted:
-        logger.info("Removing %d stale page(s) from local export.", len(deleted))
     LockfileManager.remove_pages(deleted)
 
 

--- a/confluence_markdown_exporter/utils/lockfile.py
+++ b/confluence_markdown_exporter/utils/lockfile.py
@@ -28,6 +28,18 @@ logger = logging.getLogger(__name__)
 LOCKFILE_VERSION = 2
 
 
+def _try_unlink(path: Path) -> bool:
+    """Delete *path*, returning True if it existed. Never raises."""
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        logger.warning("Failed to delete stale file: %s", path)
+        return False
+    return True
+
+
 class AttachmentEntry(BaseModel):
     """Entry for a single attachment tracked in the lock file."""
 
@@ -306,6 +318,65 @@ class LockfileManager:
         return set(cls._lock.all_pages().keys()) - cls._seen_page_ids
 
     @classmethod
+    def _unlink_page_files(cls, export_path: str) -> bool:
+        """Delete the page file at *export_path* and its comments sidecar.
+
+        Returns True if the page file itself existed and was removed.
+        """
+        if cls._output_path is None:
+            return False
+        target = cls._output_path / export_path
+        removed = _try_unlink(target)
+        _try_unlink(target.parent / f"{target.stem}.comments.md")
+        return removed
+
+    @classmethod
+    def _resolves_to_same_file(cls, old_path: str, new_path: str) -> bool:
+        """Check whether two export paths are the same file on disk.
+
+        Paths are compared as strings elsewhere, but a case-only rename on a
+        case-insensitive filesystem re-exports the page through the very file
+        the old path points at. Deleting it would discard the new content.
+        """
+        if cls._output_path is None:
+            return False
+        try:
+            return (cls._output_path / old_path).samefile(cls._output_path / new_path)
+        except OSError:
+            return False
+
+    @classmethod
+    def _remove_moved_page_files(
+        cls,
+        current_entries: dict[str, PageEntry],
+        path_owners: dict[str, set[str]],
+    ) -> None:
+        """Delete the previous file of every seen page whose export path changed."""
+        for page_id in cls._seen_page_ids:
+            old_entry = cls._all_entries_snapshot.get(page_id)
+            new_entry = current_entries.get(page_id)
+            if old_entry is None or new_entry is None:
+                continue
+            if old_entry.export_path == new_entry.export_path:
+                continue
+            if cls._resolves_to_same_file(old_entry.export_path, new_entry.export_path):
+                logger.debug(
+                    "Old and new path of page %s are the same file — keeping %s",
+                    page_id,
+                    old_entry.export_path,
+                )
+                continue
+            if path_owners.get(old_entry.export_path, set()) - {page_id}:
+                logger.debug(
+                    "Old path of moved page %s is now used by another page — keeping %s",
+                    page_id,
+                    old_entry.export_path,
+                )
+                continue
+            if cls._unlink_page_files(old_entry.export_path):
+                logger.info("Deleted old path for moved page: %s", old_entry.export_path)
+
+    @classmethod
     def remove_pages(cls, deleted_ids: set[str]) -> None:
         """Remove files and lockfile entries for moved or deleted pages.
 
@@ -315,24 +386,24 @@ class LockfileManager:
         if cls._lock is None or cls._lockfile_path is None or cls._output_path is None:
             return
 
-        result_delete_ids: set[str] = set()
+        current_entries = cls._lock.all_pages()
+        path_owners: dict[str, set[str]] = {}
+        for page_id, entry in current_entries.items():
+            path_owners.setdefault(entry.export_path, set()).add(page_id)
 
-        # Handle moved pages: delete old file when export_path changed
-        for page_id in cls._seen_page_ids:
-            if page_id in cls._all_entries_snapshot:
-                old_entry = cls._all_entries_snapshot[page_id]
-                new_entry = cls._lock.get_page(page_id)
-                if new_entry and old_entry.export_path != new_entry.export_path:
-                    (cls._output_path / old_entry.export_path).unlink(missing_ok=True)
-                    logger.info("Deleted old path for moved page: %s", old_entry.export_path)
+        cls._remove_moved_page_files(current_entries, path_owners)
 
         # Remove files and lockfile entries for pages deleted from Confluence
+        result_delete_ids: set[str] = set()
         for page_id in deleted_ids:
-            entry = cls._lock.get_page(page_id)
-            if entry:
-                (cls._output_path / entry.export_path).unlink(missing_ok=True)
+            entry = current_entries.get(page_id)
+            if entry is None:
+                continue
+            result_delete_ids.add(page_id)
+            if path_owners.get(entry.export_path, set()) - {page_id}:
+                logger.debug("Path of deleted page %s is claimed by another page.", page_id)
+            elif cls._unlink_page_files(entry.export_path):
                 logger.info("Deleted removed page: %s", entry.export_path)
-                result_delete_ids.add(page_id)
 
         if result_delete_ids:
             with cls._thread_lock:

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -338,7 +338,9 @@ Skip exporting pages that have not changed since last export. Uses a lockfile to
 
 ### export.cleanup_stale
 
-After export, delete local files for pages removed from Confluence or whose export path has changed.
+After export, delete local files for pages removed from Confluence or whose export path has changed. Renaming or moving a page in Confluence changes its export path, so the file at the previous path is removed along with its `.comments.md` sidecar. Renaming a parent page also changes the path of every descendant, because `{ancestor_titles}` is part of the default `export.page_path`.
+
+The old file is kept when another page now occupies that exact path, and when the old and new paths are the same file on disk. The latter happens on a case-only rename on a case-insensitive filesystem such as the macOS or Windows default.
 
 - Default: `True`
 - ENV Var: `CME_EXPORT__CLEANUP_STALE`

--- a/tests/unit/utils/test_lockfile.py
+++ b/tests/unit/utils/test_lockfile.py
@@ -410,6 +410,139 @@ class TestLockfileManagerCleanup:
 
             assert not old_file.exists()
 
+    def test_cleanup_deletes_comments_sidecar_for_moved_page(self) -> None:
+        """A moved page's '.comments.md' sidecar is deleted along with the page."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            old_file = output / "old" / "Page.md"
+            old_file.parent.mkdir(parents=True)
+            old_file.write_text("old content")
+            old_sidecar = output / "old" / "Page.comments.md"
+            old_sidecar.write_text("old comments")
+            new_sidecar = output / "new" / "Page.comments.md"
+            new_sidecar.parent.mkdir(parents=True)
+            new_sidecar.write_text("new comments")
+
+            lockfile_path = output / LOCKFILE_FILENAME
+            LockfileManager._output_path = output
+            LockfileManager._lockfile_path = lockfile_path
+            LockfileManager._all_entries_snapshot = {
+                "100": PageEntry(title="Page", version=1, export_path="old/Page.md"),
+            }
+            LockfileManager._lock = _lock_with_pages({
+                "100": PageEntry(title="Page", version=2, export_path="new/Page.md"),
+            })
+            LockfileManager._seen_page_ids = {"100"}
+
+            LockfileManager.remove_pages(set())
+
+            assert not old_file.exists()
+            assert not old_sidecar.exists()
+            assert new_sidecar.read_text() == "new comments"
+
+    def test_cleanup_deletes_comments_sidecar_for_removed_page(self) -> None:
+        """A deleted page's '.comments.md' sidecar is deleted along with the page."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            md_file = output / "space" / "Removed.md"
+            md_file.parent.mkdir(parents=True)
+            md_file.write_text("content")
+            sidecar = output / "space" / "Removed.comments.md"
+            sidecar.write_text("comments")
+
+            lockfile_path = output / LOCKFILE_FILENAME
+            LockfileManager._output_path = output
+            LockfileManager._lockfile_path = lockfile_path
+            LockfileManager._lock = _lock_with_pages({
+                "100": PageEntry(title="Removed", version=1, export_path="space/Removed.md"),
+            })
+            LockfileManager._all_entries_snapshot = dict(LockfileManager._lock.all_pages())
+            LockfileManager._seen_page_ids = set()
+
+            LockfileManager.remove_pages({"100"})
+
+            assert not md_file.exists()
+            assert not sidecar.exists()
+
+    def test_cleanup_keeps_old_path_taken_by_another_page(self) -> None:
+        """Two pages swapping export paths keep both freshly exported files."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            (output / "a").mkdir()
+            file_x = output / "a" / "X.md"
+            file_x.write_text("now page 200")
+            file_y = output / "a" / "Y.md"
+            file_y.write_text("now page 100")
+
+            lockfile_path = output / LOCKFILE_FILENAME
+            LockfileManager._output_path = output
+            LockfileManager._lockfile_path = lockfile_path
+            LockfileManager._all_entries_snapshot = {
+                "100": PageEntry(title="X", version=1, export_path="a/X.md"),
+                "200": PageEntry(title="Y", version=1, export_path="a/Y.md"),
+            }
+            LockfileManager._lock = _lock_with_pages({
+                "100": PageEntry(title="Y", version=2, export_path="a/Y.md"),
+                "200": PageEntry(title="X", version=2, export_path="a/X.md"),
+            })
+            LockfileManager._seen_page_ids = {"100", "200"}
+
+            LockfileManager.remove_pages(set())
+
+            assert file_x.read_text() == "now page 200"
+            assert file_y.read_text() == "now page 100"
+
+    def test_cleanup_keeps_file_on_case_only_rename(self) -> None:
+        """A case-only rename must not delete the freshly exported file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            (output / "a").mkdir()
+            exported = output / "a" / "Page.md"
+            exported.write_text("new content")
+            if not (output / "a" / "PAGE.md").exists():
+                pytest.skip("Filesystem is case-sensitive")
+
+            lockfile_path = output / LOCKFILE_FILENAME
+            LockfileManager._output_path = output
+            LockfileManager._lockfile_path = lockfile_path
+            LockfileManager._all_entries_snapshot = {
+                "100": PageEntry(title="Page", version=1, export_path="a/Page.md"),
+            }
+            LockfileManager._lock = _lock_with_pages({
+                "100": PageEntry(title="PAGE", version=2, export_path="a/PAGE.md"),
+            })
+            LockfileManager._seen_page_ids = {"100"}
+
+            LockfileManager.remove_pages(set())
+
+            assert exported.read_text() == "new content"
+
+    def test_cleanup_keeps_path_claimed_by_another_page_on_delete(self) -> None:
+        """A deleted page's file is kept when another page now occupies its path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            md_file = output / "space" / "Notes.md"
+            md_file.parent.mkdir(parents=True)
+            md_file.write_text("now page 200")
+
+            lockfile_path = output / LOCKFILE_FILENAME
+            LockfileManager._output_path = output
+            LockfileManager._lockfile_path = lockfile_path
+            LockfileManager._lock = _lock_with_pages({
+                "100": PageEntry(title="Notes", version=1, export_path="space/Notes.md"),
+                "200": PageEntry(title="Notes", version=1, export_path="space/Notes.md"),
+            })
+            LockfileManager._all_entries_snapshot = dict(LockfileManager._lock.all_pages())
+            LockfileManager._seen_page_ids = {"200"}
+
+            LockfileManager.remove_pages({"100"})
+
+            assert md_file.read_text() == "now page 200"
+            saved = json.loads(lockfile_path.read_text(encoding="utf-8"))
+            pages = saved["orgs"][_TEST_BASE_URL]["spaces"][_TEST_SPACE_KEY]["pages"]
+            assert "100" not in pages
+            assert "200" in pages
+
     def test_cleanup_keeps_page_existing_on_confluence(self) -> None:
         """Unseen pages that still exist on Confluence are kept."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -551,6 +684,110 @@ class TestFetchDeletedPageIds:
         fetch_deleted_page_ids(ids, _TEST_BASE_URL)
 
         assert mock_client.get.call_count == 2
+
+
+class TestSyncRemovedPages:
+    """Test cases for sync_removed_pages, the only caller of remove_pages."""
+
+    @staticmethod
+    def _setup_moved_page(output: Path) -> tuple[Path, Path]:
+        """Stage a renamed page: old file and new file both on disk."""
+        old_file = output / "old" / "Page.md"
+        old_file.parent.mkdir(parents=True)
+        old_file.write_text("old content")
+        new_file = output / "new" / "Page.md"
+        new_file.parent.mkdir(parents=True)
+        new_file.write_text("new content")
+
+        LockfileManager._output_path = output
+        LockfileManager._lockfile_path = output / LOCKFILE_FILENAME
+        LockfileManager._all_entries_snapshot = {
+            "100": PageEntry(title="Page", version=1, export_path="old/Page.md"),
+        }
+        LockfileManager._lock = _lock_with_pages({
+            "100": PageEntry(title="Renamed Page", version=2, export_path="new/Page.md"),
+        })
+        LockfileManager._seen_page_ids = {"100"}
+        return old_file, new_file
+
+    @patch("confluence_markdown_exporter.confluence.settings")
+    def test_renamed_page_old_file_deleted_when_nothing_unseen(
+        self, mock_settings: MagicMock
+    ) -> None:
+        """A renamed page's old file is deleted even though no page is unseen."""
+        from confluence_markdown_exporter.confluence import sync_removed_pages
+
+        mock_settings.export.cleanup_stale = True
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            old_file, new_file = self._setup_moved_page(output)
+            assert LockfileManager.unseen_ids() == set()
+
+            sync_removed_pages(_TEST_BASE_URL)
+
+            assert not old_file.exists()
+            assert new_file.read_text() == "new content"
+            assert LockfileManager._lock is not None
+            assert LockfileManager._lock.get_page("100") is not None
+
+    @patch("confluence_markdown_exporter.confluence.fetch_deleted_page_ids")
+    @patch("confluence_markdown_exporter.confluence.settings")
+    def test_existence_check_skipped_when_all_pages_seen(
+        self, mock_settings: MagicMock, mock_fetch: MagicMock
+    ) -> None:
+        """No API existence check is made when every lockfile page was seen."""
+        from confluence_markdown_exporter.confluence import sync_removed_pages
+
+        mock_settings.export.cleanup_stale = True
+        with tempfile.TemporaryDirectory() as tmp:
+            self._setup_moved_page(Path(tmp))
+
+            sync_removed_pages(_TEST_BASE_URL)
+
+            mock_fetch.assert_not_called()
+
+    @patch("confluence_markdown_exporter.confluence.fetch_deleted_page_ids")
+    @patch("confluence_markdown_exporter.confluence.settings")
+    def test_existence_check_still_runs_for_unseen_pages(
+        self, mock_settings: MagicMock, mock_fetch: MagicMock
+    ) -> None:
+        """Unseen pages are checked against the API and deleted ones removed."""
+        from confluence_markdown_exporter.confluence import sync_removed_pages
+
+        mock_settings.export.cleanup_stale = True
+        mock_fetch.return_value = {"200"}
+        with tempfile.TemporaryDirectory() as tmp:
+            output = Path(tmp)
+            gone_file = output / "old" / "Gone.md"
+            gone_file.parent.mkdir(parents=True)
+            gone_file.write_text("gone")
+
+            LockfileManager._output_path = output
+            LockfileManager._lockfile_path = output / LOCKFILE_FILENAME
+            LockfileManager._lock = _lock_with_pages({
+                "100": PageEntry(title="Kept", version=1, export_path="old/Kept.md"),
+                "200": PageEntry(title="Gone", version=1, export_path="old/Gone.md"),
+            })
+            LockfileManager._all_entries_snapshot = dict(LockfileManager._lock.all_pages())
+            LockfileManager._seen_page_ids = {"100"}
+
+            sync_removed_pages(_TEST_BASE_URL)
+
+            mock_fetch.assert_called_once_with(["200"], _TEST_BASE_URL)
+            assert not gone_file.exists()
+
+    @patch("confluence_markdown_exporter.confluence.settings")
+    def test_noop_when_cleanup_stale_disabled(self, mock_settings: MagicMock) -> None:
+        """Nothing is deleted when cleanup_stale is disabled."""
+        from confluence_markdown_exporter.confluence import sync_removed_pages
+
+        mock_settings.export.cleanup_stale = False
+        with tempfile.TemporaryDirectory() as tmp:
+            old_file, _ = self._setup_moved_page(Path(tmp))
+
+            sync_removed_pages(_TEST_BASE_URL)
+
+            assert old_file.exists()
 
 
 class TestConfluenceLockSave:


### PR DESCRIPTION

Fixes #320

## What

`sync_removed_pages` now always runs the moved-page cleanup in `LockfileManager.remove_pages`, instead of returning early whenever no page is unseen. The API existence check is still skipped when there is nothing unseen, so this costs no extra requests.

A page's `.comments.md` sidecar is now deleted along with the page, for renamed and deleted pages alike.

## Why

A renamed page is seen during the export run, so it never appears in `unseen_ids()`. On a full-space sync where nothing was deleted in Confluence, `unseen` is empty and `sync_removed_pages` returned before calling `remove_pages`. The moved-page unlink loop inside it was therefore unreachable in the common case, and the file under the old title survived. Renaming a parent page left the entire old subtree behind, because `{ancestor_titles}` is part of the default `export.page_path`.

The existing test for that loop called `remove_pages` directly, which is why it passed while the real path stayed broken.

## Guards

Making the loop run on every sync arms a delete path that previously almost never executed, so two guards ship with it.

The first covers case-only renames. `should_export` compares export paths as strings, but on a case-insensitive filesystem, which is the macOS and Windows default, re-exporting `Page` as `PAGE` writes through the same file. Unlinking the old path would then delete the content just written. `_resolves_to_same_file` skips the unlink when both paths are the same file on disk.

The second covers path reuse. If another page now occupies the old path, say after renaming `Release Notes` to `Release Notes 2025` and creating a fresh `Release Notes`, that path belongs to a live page. A path-ownership check skips those.

Unlink failures other than "file not found" are now logged rather than raised, so a file held open by another process cannot fail the command at the end of an otherwise successful export.

## Tests

Nine tests added, six of which fail on `main`:

- The regression test drives `sync_removed_pages` with no unseen pages and asserts the old file is deleted, the new file survives, and the lockfile entry is kept.
- Two tests pin the existing behaviour of skipping and running the API existence check.
- Two cover sidecar removal, on rename and on delete.
- Three guard tests: two pages swapping paths, a case-only rename, and a deleted page whose path another page has taken.

Verified end to end against a real 842-page lockfile with a renamed parent and two children. On `main` all six stale files survive. With this change all six are removed and the new files are intact.

## Known limitations, not addressed here

- Empty directories are left behind after a rename moves a subtree.
- Pages linking to the renamed page are not re-exported, since their own version and path did not change, so their relative links now point at a deleted file. Previously the stale file absorbed those links.
- A page moved between spaces keeps an entry under both space keys, because `add_page` never removes the old one.
- Attachments only move on rename if `attachment_path` is customised to include title components. The default template does not.
- `cleanup_stale=true` with `skip_unchanged=false` still does nothing, because `LockfileManager.init` returns before setting `_lock`.

## Behaviour change worth noting

Changing `export.page_path` now deletes the old tree on the next sync, since every page's path changes at once. That matches what `cleanup_stale` documents, but anyone relying on the old files lingering will notice.
