### PR TITLE
Add path-template options enabling index.md directory structure

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -3,6 +3,8 @@
 https://developer.atlassian.com/cloud/confluence/rest/v1/intro
 """
 
+from __future__ import annotations
+
 import functools
 import html
 import json
@@ -727,6 +729,9 @@ class Attachment(Document):
         ext = self.extension
         title = self.title
         title_without_ext = title[: -len(ext)] if ext and title.endswith(ext) else Path(title).stem
+
+        ancestors_without_last = [sanitize_filename(a.title) for a in self.ancestors[0:-1]]
+
         return {
             **super()._template_vars,
             "attachment_id": str(self.id),
@@ -737,11 +742,21 @@ class Attachment(Document):
             # present and unique.
             "attachment_file_id": self.file_id or str(self.id),
             "attachment_extension": self.extension,
+            "ancestors_without_last": "/".join(ancestors_without_last),
         }
+
+    def _attachment_template(self):
+        if len(self.ancestors) > 0:
+            owning_page = self.ancestors[-1]
+            has_descendants = len(_descendants(owning_page)) > 0
+            if has_descendants and (parent_template := settings.export.attachment_path_if_parent):
+                return parent_template
+        return settings.export.attachment_path
 
     @property
     def export_path(self) -> Path:
-        filepath_template = Template(settings.export.attachment_path.replace("{", "${"))
+        template = self._attachment_template()
+        filepath_template = Template(template.replace("{", "${"))
         return Path(filepath_template.safe_substitute(self._template_vars))
 
     @classmethod
@@ -848,6 +863,19 @@ class Ancestor(Document):
         )
 
 
+def _page_template_vars(page: Document | Page):
+    page_title = sanitize_filename(page.title)
+
+    return {
+        "page_id": str(page.id),
+        "page_title": page_title,
+    }
+
+def _export_page_path_template(has_descendants: bool):
+    if has_descendants and (parent_template := settings.export.page_path_if_parent):
+        return parent_template
+    return settings.export.page_path
+
 class Descendant(Document):
     id: int
 
@@ -855,13 +883,13 @@ class Descendant(Document):
     def _template_vars(self) -> dict[str, str]:
         return {
             **super()._template_vars,
-            "page_id": str(self.id),
-            "page_title": sanitize_filename(self.title),
+            **_page_template_vars(self)
         }
 
     @property
     def export_path(self) -> Path:
-        filepath_template = Template(settings.export.page_path.replace("{", "${"))
+        template = _export_page_path_template(has_descendants=len(_descendants(self)) > 0)
+        filepath_template = Template(template.replace("{", "${"))
         return Path(filepath_template.safe_substitute(self._template_vars))
 
     @classmethod
@@ -909,6 +937,41 @@ def _parse_image_captions(storage_xml: str) -> dict[str, str]:
     return captions
 
 
+def _descendants(page: Page | Descendant | Ancestor) -> list[Descendant]:
+    url = "rest/api/content/search"
+    params = {
+        "cql": f"type=page AND ancestor={page.id}",
+        "expand": "metadata.properties,ancestors,version",
+        "limit": 250,
+    }
+    results = []
+    client = get_thread_confluence(page.base_url)
+
+    try:
+        response = cast("dict", client.get(url, params=params))
+        results.extend(response.get("results", []))
+        next_path = response.get("_links", {}).get("next")
+
+        while next_path:
+            response = cast("dict", client.get(next_path))
+            results.extend(response.get("results", []))
+            next_path = response.get("_links", {}).get("next")
+
+    except HTTPError as e:
+        if e.response.status_code == 404:  # noqa: PLR2004
+            logger.warning(
+                f"Content with ID {page.id} not found (404) when fetching descendants."
+            )
+            return []
+        return []
+    except Exception:
+        logger.exception(
+            f"Unexpected error when fetching descendants for content ID {page.id}."
+        )
+        return []
+    return [Descendant.from_json(result, page.base_url) for result in results]
+
+
 class Page(Document):
     id: int
     type: str = ""
@@ -926,50 +989,19 @@ class Page(Document):
 
     @property
     def descendants(self) -> list["Descendant"]:
-        url = "rest/api/content/search"
-        params = {
-            "cql": f"type=page AND ancestor={self.id}",
-            "expand": "metadata.properties,ancestors,version",
-            "limit": 250,
-        }
-        results = []
-        client = get_thread_confluence(self.base_url)
-
-        try:
-            response = cast("dict", client.get(url, params=params))
-            results.extend(response.get("results", []))
-            next_path = response.get("_links", {}).get("next")
-
-            while next_path:
-                response = cast("dict", client.get(next_path))
-                results.extend(response.get("results", []))
-                next_path = response.get("_links", {}).get("next")
-
-        except HTTPError as e:
-            if e.response.status_code == 404:  # noqa: PLR2004
-                logger.warning(
-                    f"Content with ID {self.id} not found (404) when fetching descendants."
-                )
-                return []
-            return []
-        except Exception:
-            logger.exception(
-                f"Unexpected error when fetching descendants for content ID {self.id}."
-            )
-            return []
-        return [Descendant.from_json(result, self.base_url) for result in results]
+        return _descendants(self)
 
     @property
     def _template_vars(self) -> dict[str, str]:
         return {
             **super()._template_vars,
-            "page_id": str(self.id),
-            "page_title": sanitize_filename(self.title),
+            **_page_template_vars(self)
         }
 
     @property
     def export_path(self) -> Path:
-        filepath_template = Template(settings.export.page_path.replace("{", "${"))
+        template = _export_page_path_template(has_descendants=len(self.descendants)> 0)
+        filepath_template = Template(template.replace("{", "${"))
         return Path(filepath_template.safe_substitute(self._template_vars))
 
     @property

--- a/confluence_markdown_exporter/utils/app_data_store.py
+++ b/confluence_markdown_exporter/utils/app_data_store.py
@@ -369,6 +369,17 @@ class ExportConfig(BaseModel):
         ),
         examples=["{space_name}/{page_title}.md"],
     )
+    page_path_if_parent: str | None = Field(
+        default=None,
+        title="Page Path Template if the page has subpages",
+        description=(
+            "Template for exported page file paths.\n"
+            "Available variables: see `export.page_path`\n"
+            "If unset, uses the same template as `export.page_path`\n"
+            "Useful for naming top-level directories with subpages as `index.md`/`README.md`, in that case exclude `{page_title}` from the template.\n"
+        ),
+        examples=["{space_name}/{ancestor_titles}/README.md"],
+    )
     attachment_href: Literal["absolute", "relative", "wiki"] = Field(
         default="relative",
         title="Attachment Href Style",
@@ -390,7 +401,8 @@ class ExportConfig(BaseModel):
             "  - {homepage_id}: The ID of the homepage of the Confluence space.\n"
             "  - {homepage_title}: The title of the homepage of the Confluence space.\n"
             "  - {ancestor_ids}: A slash-separated list of ancestor page IDs.\n"
-            "  - {ancestor_titles}: A slash-separated list of ancestor page titles.\n"
+            "  - {ancestor_titles}: A slash-separated list of ancestor page titles. Including the page title of the page holding the attachment itself.\n"
+            " -  {ancestors_without_last}: A slash-separated list of ancestor page titles. Excluding the page title of the page holding the attachment itself.\n"
             "  - {attachment_id}: The unique ID of the attachment.\n"
             "  - {attachment_title}: The title of the attachment (without file extension).\n"
             "  - {attachment_file_id}: The file ID of the attachment. Falls back to "
@@ -399,7 +411,18 @@ class ExportConfig(BaseModel):
             "  - {attachment_extension}: The file extension of the attachment,\n"
             "including the leading dot."
         ),
-        examples=["{space_name}/attachments/{attachment_file_id}{attachment_extension}"],
+        examples=["{space_name}/attachments/{attachment_file_id}{attachment_extension}",
+                  "{space_name}/{homepage_title}/{ancestors_without_last}/media/{attachment_title}{attachment_extension}"
+                  ],
+    )
+    attachment_path_if_parent: str | None = Field(
+        default=None,
+        title="Attachment Path Template",
+        description=(
+            "Template for exported attachment file paths if the page has any child-pages.\n"
+            "Available variables: See `export.attachment_path`\n"
+        ),
+        examples=["{space_name}/{homepage_title}/{ancestor_titles}/media/{attachment_title}{attachment_extension}"],
     )
 
     @field_validator("attachment_path", mode="before")

--- a/docs/configuration/options.md
+++ b/docs/configuration/options.md
@@ -42,6 +42,35 @@ Path template for exported pages.
 - Default: `{space_name}/{homepage_title}/{ancestor_titles}/{page_title}.md`
 - ENV Var: `CME_EXPORT__PAGE_PATH`
 
+### export.page_path_if_parent
+
+Overrides `export.page_path` on pages having descendant child-pages.
+
+- Default: `None`, in which case `export.page_path` is used.
+- ENV Var: `CME_EXPORT__PAGE_PATH`
+
+Useful for renaming parent pages into `README.md`/`index.md`, while keeping their name as the directory name instead. 
+
+Example usage, together with `export.attachment_path_if_parent`: 
+```
+export.page_path                 = {ancestor_titles}/{page_title}.md
+export.page_path_if_parent       = {ancestor_titles}/{page_title}/README.md
+export.attachment_path           = {ancestors_without_last}/_assets/{attachment_title}{attachment_extension}
+export.attachment_path_if_parent = {ancestor_titles}/_assets/{attachment_title}{attachment_extension}
+```
+Will create output like:
+```
+├── _assets
+│   └── diagram_a.png            # linked from PageA
+├── PageB
+│   ├── _assets
+│   │      ├── diagram_b.png     # Linked from PageB  (now PageB/README.md)
+│   │      └── diagram_c.png     # Linked from PageC
+│   ├── PageC.md
+│   └── README.md                # In confluence this was PageB
+└── PageA                        # Does not have child-pages => not renamed to PageA/README.md
+```
+
 ### export.attachment_href
 
 How to generate links to attachments in Markdown. Options: `relative` (default), `absolute`, or `wiki`.
@@ -63,6 +92,17 @@ Path template for attachments.
 - ENV Var: `CME_EXPORT__ATTACHMENT_PATH`
 
 On Confluence Data Center / Server, where the API does not provide `fileId`, `{attachment_file_id}` falls back to the content id, so the default template still produces unique filenames.
+
+
+### export.attachment_path_if_parent
+
+Overrides `export.attachment_path` on pages having descendant child-pages.
+
+
+- Default: `None`, in which case `export.attachment_path` is used
+- ENV Var: `CME_EXPORT__ATTACHMENT_PATH_IF_PARENT`
+
+See `export.export.page_path_if_parent` for example usage.
 
 ### export.attachments_export
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,16 @@ _original_get_confluence = None
 _original_get_jira = None
 
 
+def _confluence_mock():
+    mock_confluence = MagicMock()
+
+    def _get(*args, **kwargs):
+        # Prevent _descendants() getting stuck iterating over `next_path` being infinite series of `MagicMock`
+        raise Exception("Unmocked get-call")
+
+    mock_confluence.get.side_effect = _get
+    mock_confluence.get_all_spaces.return_value = []
+
 def pytest_configure(config: pytest.Config) -> None:  # noqa: ARG001
     """Configure pytest and mock API clients before test collection."""
     import confluence_markdown_exporter.api_clients
@@ -42,13 +52,10 @@ def pytest_configure(config: pytest.Config) -> None:  # noqa: ARG001
     _original_get_jira = confluence_markdown_exporter.api_clients.get_jira_instance
 
     # Create mock objects that will be returned by the wrapper
-    mock_confluence = MagicMock()
-    mock_confluence.get_all_spaces.return_value = []
-
     mock_jira = MagicMock()
 
     # Replace with wrapper functions that return mocks
-    confluence_markdown_exporter.api_clients.get_confluence_instance = lambda _url: mock_confluence
+    confluence_markdown_exporter.api_clients.get_confluence_instance = lambda _url: _confluence_mock
     confluence_markdown_exporter.api_clients.get_jira_instance = lambda _url: mock_jira
 
 
@@ -97,12 +104,10 @@ def restore_api_functions_for_specific_tests(
 
     # Re-apply mocks after the test
     if is_api_client_function_test:
-        mock_confluence = MagicMock()
-        mock_confluence.get_all_spaces.return_value = []
         mock_jira = MagicMock()
 
         confluence_markdown_exporter.api_clients.get_confluence_instance = (
-            lambda _url: mock_confluence
+            lambda _url: _confluence_mock
         )
         confluence_markdown_exporter.api_clients.get_jira_instance = lambda _url: mock_jira
 


### PR DESCRIPTION
Adds two new options `export.page_path_if_parent` +  `export.attachment_path_if_parent` that, together with a new template variable `ancestors_without_last`, allows creating a directory structure where parent pages are renamed to `README.md` or `index.md`. 

This structure is compatible with many popular Markdown renderers, such as GitHub, GitLab, Gitiles, Mkdocs, Docusaurus, where the `index.md`  is treated as the content for the containing directory.

Example usage:
```
export.page_path                 = {ancestor_titles}/{page_title}.md
export.page_path_if_parent       = {ancestor_titles}/{page_title}/README.md
export.attachment_path           = {ancestors_without_last}/_assets/{attachment_title}{attachment_extension}
export.attachment_path_if_parent = {ancestor_titles}/_assets/{attachment_title}{attachment_extension}
```
Will create output like:
```
├── _assets
│   └── diagram_a.png            # linked from PageA
├── PageB                        # PageB has children in Confluence, exported as directory with a README.md
│   ├── _assets
│   │      ├── diagram_b.png     # Linked from PageB  (now PageB/README.md)
│   │      └── diagram_c.png     # Linked from PageC
│   ├── PageC.md
│   └── README.md                # In confluence this was PageB
└── PageA                        # Does not have child-pages => not renamed to PageA/README.md
```