### PR TITLE
feat(links): resolve Confluence tiny links (/wiki/x/) to pages

### DIFF
--- a/confluence_markdown_exporter/api_clients.py
+++ b/confluence_markdown_exporter/api_clients.py
@@ -1,5 +1,8 @@
+import base64
+import binascii
 import logging
 import re
+import struct
 import urllib.parse
 from threading import Lock
 from threading import local
@@ -97,7 +100,8 @@ def _decode_url_part(v: str | None) -> None | str:
 
 
 class ConfluenceRef(BaseModel):
-    space_key: Annotated[str, AfterValidator(_decode_url_part)]
+    # A tiny link carries only a page id, so the space key is optional.
+    space_key: Annotated[str | None, AfterValidator(_decode_url_part)] = None
     page_id: int | None = None
     page_title: Annotated[str | None, AfterValidator(_decode_url_part)] = None
 
@@ -117,19 +121,46 @@ _SERVER_URL_RE = re.compile(
     r"(?:/(?P<page_title>[^/?#]+))?/?$"
 )
 
+# 3) Tiny link [/wiki]/x/{tiny_id}: the "Copy link" shortlink, which encodes the page id
+_TINY_URL_RE = re.compile(
+    r"^(?:/ex/confluence/[^/]+)?(?:/wiki)?/x/(?P<tiny_id>[A-Za-z0-9_-]{1,11})$"
+)
+
+
+def decode_tiny_link_page_id(identifier: str) -> int | None:
+    """Decode the identifier of a Confluence tiny link (``/wiki/x/{identifier}``) to a page id.
+
+    The identifier is the page id as a little-endian 64-bit integer, base64 encoded with
+    ``/`` and ``+`` replaced by ``-`` and ``_``, and trailing ``A`` and ``=`` characters
+    stripped. Returns ``None`` when the identifier cannot be decoded.
+    """
+    if not identifier or not re.fullmatch(r"[A-Za-z0-9_-]{1,11}", identifier):
+        return None
+    padded = identifier.replace("-", "/").replace("_", "+").ljust(11, "A") + "="
+    try:
+        (page_id,) = struct.unpack("<q", base64.b64decode(padded, validate=True))
+    except (binascii.Error, struct.error):
+        return None
+    return page_id if page_id > 0 else None
+
 
 def parse_confluence_path(path: str) -> ConfluenceRef | None:
     """Parse only the path portion of a Confluence URL and return a ConfluenceRef dict.
 
     Matching order:
-      1) Cloud [/wiki]/spaces/{space_key}[/pages/{page_id}[/{page_title}]]
-      2) Server [/display]/{space_key}[/{page_title}]
+      1) Tiny link [/wiki]/x/{tiny_id}
+      2) Cloud [/wiki]/spaces/{space_key}[/pages/{page_id}[/{page_title}]]
+      3) Server [/display]/{space_key}[/{page_title}]
     """
     if not path:
         return None
     if not path.startswith("/"):
         path = "/" + path
     path = path.rstrip("/")
+
+    if m := _TINY_URL_RE.match(path):
+        page_id = decode_tiny_link_page_id(m.group("tiny_id"))
+        return ConfluenceRef(page_id=page_id) if page_id else None
 
     if m := _CLOUD_URL_RE.match(path) or _SERVER_URL_RE.match(path):
         return ConfluenceRef.model_validate(m.groupdict())

--- a/docs/features.md
+++ b/docs/features.md
@@ -11,6 +11,7 @@ Exports individual pages, pages with descendants, or entire spaces via the Atlas
 ### Content & formatting
 
 - **Rich text**: headings, paragraphs, bold, italic, underline, lists, tables, links, images, attachments, and image captions
+- **Page links**: links to Confluence pages become relative Markdown links, whether they were inserted as page links, pasted as full page URLs, or pasted as tiny links (`/wiki/x/...`, the "Copy link" shortlink)
 - **Code blocks**: language-aware fenced code blocks
 - **Task lists**: checkboxes with completion state
 - **Text highlights & font colours**: preserved with inline HTML colour styling

--- a/tests/unit/test_api_clients.py
+++ b/tests/unit/test_api_clients.py
@@ -12,6 +12,7 @@ from pydantic import SecretStr
 from confluence_markdown_exporter.api_clients import ApiClientFactory
 from confluence_markdown_exporter.api_clients import AuthNotConfiguredError
 from confluence_markdown_exporter.api_clients import ConfluenceRef
+from confluence_markdown_exporter.api_clients import decode_tiny_link_page_id
 from confluence_markdown_exporter.api_clients import get_confluence_instance
 from confluence_markdown_exporter.api_clients import parse_confluence_path
 from confluence_markdown_exporter.api_clients import response_hook
@@ -136,8 +137,71 @@ _PARSE_CONFLUENCE_PATH_CASES = [
         "/spaces/~jane.doe/overview",
         ConfluenceRef(space_key="~jane.doe"),
     ),
-
+    # Tiny links (the "Copy link" shortlink) carry an encoded page id and no space key.
+    (
+        "https://company.atlassian.net/wiki/x/Fc1bBw",
+        ConfluenceRef(page_id=123456789),
+    ),
+    (
+        "/wiki/x/Fc1bBw",
+        ConfluenceRef(page_id=123456789),
+    ),
+    (
+        "/x/Fc1bBw",
+        ConfluenceRef(page_id=123456789),
+    ),
+    (
+        "/ex/confluence/abc-123/wiki/x/Fc1bBw",
+        ConfluenceRef(page_id=123456789),
+    ),
+    (
+        "/wiki/x/FBqZvhw",
+        ConfluenceRef(page_id=123456789012),
+    ),
+    (
+        "/wiki/x/not-a-tiny-link-identifier",
+        None,
+    ),
+    # The identifier is well-formed but decodes to a negative number, so it is not a page id.
+    (
+        "/wiki/x/----------8",
+        None,
+    ),
 ]
+
+
+class TestDecodeTinyLinkPageId:
+    """Test cases for decode_tiny_link_page_id function."""
+
+    @pytest.mark.parametrize(
+        ("identifier", "expected"),
+        [
+            ("AQ", 1),
+            ("Fc1bBw", 123456789),
+            ("6hawTAI", 9876543210),
+            # Cloud page ids are around 12 digits
+            ("FBqZvhw", 123456789012),
+            # 11 characters is the longest identifier (no trailing "A" to strip)
+            ("---------38", 9223372036854775807),
+            # "-" and "_" stand in for the URL-unsafe base64 "/" and "+"
+            ("-_", 57599),
+        ],
+    )
+    def test_decodes_known_identifiers(self, identifier: str, expected: int) -> None:
+        assert decode_tiny_link_page_id(identifier) == expected
+
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            "",
+            "not-a-tiny-link-identifier",
+            "Fc1b!w",
+            # decodes to -1: a page id must be positive
+            "----------8",
+        ],
+    )
+    def test_rejects_invalid_identifiers(self, identifier: str) -> None:
+        assert decode_tiny_link_page_id(identifier) is None
 
 
 class TestParseConfluencePath:

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -2118,6 +2118,33 @@ class TestAbsoluteUrlPageLinks:
         from_id.assert_called_once_with(123456789, source.base_url)
         assert result == "[[Linked Page]]"
 
+    def test_tiny_link_with_query_string_resolves_page(self) -> None:
+        """A shortlink from "Copy link" carries tracking parameters; only the path decides the target."""
+        from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
+
+        PageTitleRegistry.reset()
+        target = self._make_target_page(123456789, "Linked Page", "STRUCT")
+
+        source = _make_page(body="", body_export="", attachments=[])
+
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.Page.from_id",
+                return_value=target,
+            ) as from_id,
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
+            s.export.page_href = "wiki"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            conv = Page.Converter(source)
+            url = "https://example.com/wiki/x/Fc1bBw?xpis=c2hhcmVkLWxpbms&atlOrigin=abc"
+            html = f'<a href="{url}" data-card-appearance="inline">{url}</a>'
+            result = conv.convert(html).strip()
+
+        PageTitleRegistry.reset()
+        from_id.assert_called_once_with(123456789, source.base_url)
+        assert result == "[[Linked Page]]"
+
     def test_absolute_url_different_host_left_alone(self) -> None:
         source = _make_page(body="", body_export="", attachments=[])
         conv = Page.Converter(source)

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -2089,6 +2089,35 @@ class TestAbsoluteUrlPageLinks:
         PageTitleRegistry.reset()
         assert result == "[[Linked Page]]"
 
+    def test_tiny_link_same_host_resolves_page(self) -> None:
+        """A pasted shortlink (`/wiki/x/<id>`) resolves like a full page URL."""
+        from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
+
+        PageTitleRegistry.reset()
+        target = self._make_target_page(123456789, "Linked Page", "STRUCT")
+
+        source = _make_page(body="", body_export="", attachments=[])
+
+        with (
+            patch(
+                "confluence_markdown_exporter.confluence.Page.from_id",
+                return_value=target,
+            ) as from_id,
+            patch("confluence_markdown_exporter.confluence.settings") as s,
+        ):
+            s.export.page_href = "wiki"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            conv = Page.Converter(source)
+            html = (
+                '<a href="https://example.com/wiki/x/Fc1bBw" data-card-appearance="inline">'
+                "https://example.com/wiki/x/Fc1bBw</a>"
+            )
+            result = conv.convert(html).strip()
+
+        PageTitleRegistry.reset()
+        from_id.assert_called_once_with(123456789, source.base_url)
+        assert result == "[[Linked Page]]"
+
     def test_absolute_url_different_host_left_alone(self) -> None:
         source = _make_page(body="", body_export="", attachments=[])
         conv = Page.Converter(source)

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -2119,7 +2119,7 @@ class TestAbsoluteUrlPageLinks:
         assert result == "[[Linked Page]]"
 
     def test_tiny_link_with_query_string_resolves_page(self) -> None:
-        """A shortlink from "Copy link" carries tracking parameters; only the path decides the target."""
+        """A "Copy link" shortlink carries tracking parameters; only the path picks the page."""
         from confluence_markdown_exporter.utils.page_registry import PageTitleRegistry
 
         PageTitleRegistry.reset()


### PR DESCRIPTION
Closes #323.

**What**

`parse_confluence_path` now recognises tiny links (`[/wiki]/x/{id}`, also behind the `/ex/confluence/{cloudId}` gateway prefix) and returns a `ConfluenceRef` carrying the page id. A new `decode_tiny_link_page_id()` decodes the identifier offline: it is the page id as a little-endian 64-bit integer, base64 encoded with `/` and `+` replaced by `-` and `_`, with trailing `A` and `=` stripped. `ConfluenceRef.space_key` becomes optional because a tiny link has none. Both existing callers already check `if match.space_key`, and `convert_a` reads only `page_id`, so page links inside exported pages and `cme page <tiny url>` pick this up without further changes.

**Why**

See #323. A pasted "Copy link" URL kept as an inline card is exported as a bare `<https://.../wiki/x/...>` autolink instead of `[Title](path.md)`.

**Notes**

- Tiny links to pages in other spaces or to inaccessible pages behave the same way as full page URLs do today: `Page.from_id` is called for them and logs "Page not accessible" when it cannot read the page. Each resolved link costs one `Page.from_id` call, the same as for a full URL (see #298).
- The tiny shape is tried before the Cloud and Server shapes, and a well-formed identifier that decodes to a non-positive number returns `None` rather than falling through to the Server matcher. As a result `/x/{something}` is treated as a tiny link and no longer parses as a Server path with space key `x`. Confluence Server also serves tiny links at `/x/{id}` on the context root, which is why the `/wiki` prefix stays optional. I can change this to require `/wiki` if you prefer.
- Editor URLs (`/pages/edit-v2/{id}#anchor`) are a separate case and are not handled here.

**Tests**

Unit tests cover the decoder (including the `-`/`_` substitution, a 12-digit id, the longest 11-character identifier, and a negative result), the parser shapes, and `convert_a` with an inline-card anchor. `uv run pytest` (521 passed) and `uv run ruff check` are clean.

Docs: one bullet in `docs/features.md`.
