### PR TITLE
fix: Attach non *.drawio-images missing data-media-* attributes

### DIFF
--- a/confluence_markdown_exporter/confluence.py
+++ b/confluence_markdown_exporter/confluence.py
@@ -2487,6 +2487,17 @@ class Page(Document):
                     if len(drawio_images) > 0:
                         attachment = drawio_images[0]
 
+            # Confluence occasionally emits embedded images with no data-media identifiers at
+            # all, leaving the download URL as the only link back to the attachment.
+            # Resolve those by filename so they are exported as local files instead
+            # of an absolute Confluence URL.
+            if attachment is None:
+                for candidate in (url_src, str(el.get("data-image-src", ""))):
+                    if candidate:
+                        attachment = self._attachment_from_download_href(candidate)
+                        if attachment is not None:
+                            break
+
             if attachment is None:
                 href = el.get("href") or text
                 if href:

--- a/tests/unit/test_confluence.py
+++ b/tests/unit/test_confluence.py
@@ -469,6 +469,76 @@ class TestAttachmentsExportFlag:
         assert page.attachments[0].id == "att-1"
 
 
+class TestEmbeddedImageWithoutDataIds:
+    """Images without drawio in the name and carrying no data-* identifiers must resolve locally.
+
+    Confluence emits some ``confluence-embedded-image`` tags with no
+    ``data-media-id`` / ``data-linked-resource-*`` / ``data-encoded-xml``
+    attributes at all. In such scenario, the download URL in ``src``/``data-image-src`` is the
+    only link back to the attachment. Those must be resolved by filename so the
+    markdown points at the exported file instead of an absolute Confluence URL, even when
+    the file name does not end with `.drawio.png`.
+    """
+
+    # The HTML below is taken verbatim from a real page export
+    # The *-drawio.png-case is handled specially in the code, hence the two different forms
+    _HTML = (
+        """<span class="confluence-embedded-file-wrapper image-left-wrapper">
+            <img class="confluence-embedded-image confluence-external-resource image-left"
+                data-image-src="https://example.com/wiki/download/attachments/123456/bar.drawio.png?api=v2&amp;version=16"
+                loading="lazy"
+                src="https://example.com/wiki/download/attachments/123456/bar.drawio.png?api=v2&amp;version=16"
+                width="1494"/>
+            <img class="confluence-embedded-image confluence-external-resource image-left"
+                data-image-src="https://example.com/wiki/download/attachments/123456/foo.png?api=v2&amp;version=7"
+                loading="lazy" src="https://example.com/wiki/download/attachments/123456/foo.png?api=v2&amp;version=7"
+                width="1557"/>
+        "</span>"""
+    )
+
+    def _convert(self, html: str, attachments: list[Attachment]) -> str:
+        page = _make_page(body=html, body_export=html, attachments=attachments)
+        with patch("confluence_markdown_exporter.confluence.settings") as s:
+            s.export.attachment_href = "relative"
+            s.export.attachment_path = (
+                "{space_name}/media/{attachment_title}{attachment_extension}"
+            )
+            s.export.page_href = "relative"
+            s.export.page_path = "{space_name}/{page_title}.md"
+            s.export.image_captions = False
+            return Page.Converter(page).convert(html).strip()
+
+    def test_download_url_resolves_to_exported_attachment(self) -> None:
+        att = _make_attachment("xxxxx", "aaaaaaaaa", title="foo.png")
+        att2 = _make_attachment("yyyyy", "bbbbbbbbb", title = "bar.drawio.png")
+
+        result = self._convert(self._HTML, [att, att2])
+
+        assert "example.com" not in result
+        assert "wiki/download/attachments" not in result
+        assert "[](media/foo.png)" in result
+        assert "[](media/bar.drawio.png)" in result
+
+    def test_falls_back_to_url_when_attachment_is_unknown(self) -> None:
+        # No matching attachment: the original URL must be preserved, not dropped.
+        result = self._convert(self._HTML, [])
+
+        assert "https://example.com/wiki/download/attachments/123456/foo.png" in result
+
+    def test_resolves_via_data_image_src_when_src_is_absent(self) -> None:
+        att = _make_attachment(
+            "107a200c", "107a200c-ba2a-4a06-88f3-111ad53c8321", title="foo.png"
+        )
+        html = """
+            <img class="confluence-embedded-image"
+                data-image-src="https://example.com/wiki/download/attachments/983041/foo.png?api=v2&amp;version=7"/>
+        """
+        result = self._convert(html, [att])
+
+        assert "example.com" not in result
+        assert "foo.png" in result
+
+
 class TestTransformErrorImg:
     """transform-error SVG images must resolve via data-encoded-xml."""
 


### PR DESCRIPTION
Confluence sometimes return `img` tags without `data-media-*` attributes, this was previously handled by a special case only for images with `*.drawio.png` in the name. Other attachments, and diagrams without the `drawio.png` file name were lost and got linked as absolute hrefs back to the live Confluence instance.

With this fix, the `img url` and `data-image-src` is used as a fallback to resolve the attachment, ensuring all attachments are exported to the markdown tree.
